### PR TITLE
[cln] find liquid cookie file, update cln guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ dist/
 
 # build output
 out/
-peerswapd
-peerswap
-pscli

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PAYMENT_RETRY_TIME=10
 PEERSWAP_TEST_FILTER="peerswap"
 
 build:
-	go build -tags dev -o $(OUTDIR)/peerswap ./cmd/peerswap/main.go
-	chmod a+x $(OUTDIR)/peerswap
+	go build -tags dev -o $(OUTDIR)/peerswap-plugin ./cmd/peerswap-plugin/main.go
+	chmod a+x $(OUTDIR)/peerswap-plugin
 	go build -o $(OUTDIR)/peerswapd ./cmd/peerswaplnd/peerswapd/main.go
 	chmod a+x $(OUTDIR)/peerswapd
 	go build -o $(OUTDIR)/pscli ./cmd/peerswaplnd/pscli/main.go
@@ -12,8 +12,8 @@ build:
 .PHONY: build
 
 build-with-fast-test:
-	go build -tags dev -tags fast_test -o $(OUTDIR)/peerswap ./cmd/peerswap/main.go
-	chmod a+x $(OUTDIR)/peerswap
+	go build -tags dev -tags fast_test -o $(OUTDIR)/peerswap-plugin ./cmd/peerswap-plugin/main.go
+	chmod a+x $(OUTDIR)/peerswap-plugin
 	go build -tags dev -tags fast_test -o $(OUTDIR)/peerswapd ./cmd/peerswaplnd/peerswapd/main.go
 	chmod a+x $(OUTDIR)/peerswapd
 .PHONY: build-with-fast-test
@@ -52,7 +52,7 @@ lnd-install:
 .PHONY: lnd-install
 
 cln-release:
-	go build -o peerswap ./cmd/peerswap/main.go
+	go build -o peerswap-plugin ./cmd/peerswap-plugin/main.go
 .PHONY: cln-release
 
 proto:

--- a/README.md
+++ b/README.md
@@ -17,19 +17,22 @@ PeerSwap is a Peer To Peer atomic swap plugin for lightning nodes.
 
 It allows rebalancing of your channels using btc with your nodes wallet or using l-btc on the Liquid sidechain with an external Liquid installation.
 
-* [Project Status](#project-status)
-* [Getting Started](#getting-started)
-    * [Installation](#installation)
-    * [Usage](#usage)
-    * [Upgrading](#upgrading)
-* [Further Information](#further-information)
-    * [FAQ](#faq)
-    * [Signet Testing](#signet-testing)
-	* [Development](#development)
+- [PeerSwap](#peerswap)
+  - [Project Status](#project-status)
+  - [Getting Started](#getting-started)
+    - [Setup](#setup)
+    - [Usage](#usage)
+    - [Upgrading](#upgrading)
+  - [Further Information](#further-information)
+    - [FAQ](#faq)
+    - [Signet Testing](#signet-testing)
+      - [core-lightning](#core-lightning)
+      - [lnd](#lnd)
+    - [Development](#development)
 
 ## Project Status
 
-PeerSwap is beta-grade software that can be run as a [c-lightning](https://github.com/ElementsProject/lightning) plugin or as a standalone daemon/cli with [LND](https://github.com/lightningnetwork/lnd)
+PeerSwap is beta-grade software that can be run as a [core-lightning](https://github.com/ElementsProject/lightning) plugin or as a standalone daemon/cli with [LND](https://github.com/lightningnetwork/lnd)
 
 As we don't have a proven fee model for swaps yet, we only allow swaps with allowlisted peers.
 
@@ -47,9 +50,9 @@ Join our Discord to get support and give feedback
 ## Getting Started
 
 ### Setup
-you can use peerswap with lnd and cln:
+you can use peerswap with lnd and core-lighting:
 
-To run peerswap as a c-lightning plugin see the [c-lightning setup guide](./docs/setup_cln.md)
+To run peerswap as a core-lightning plugin see the [core-lightning setup guide](./docs/setup_cln.md)
 
 To run peerswap as a standalone daemon with lnd see the [lnd setup guide](./docs/setup_lnd.md)
 
@@ -79,15 +82,15 @@ See the [Upgrade guide](./docs/upgrade.md) for instructions to safely upgrade yo
 * Why should I do a `swap-in` vs opening a new channel?
   * If you want to leave the old channel open, opening a new channel is in fact cheaper than a `swap-in`. The advantage of a `swap-in` comes with using liquid, as it allows for new outbound liquidity in 2 minutes.
 
-* Running Liquid is a bit much for me, do you have anything planned?
+* Will there be an easier way to run peerswap with a liquid wallet?
   * We will provide a light wallet using [Blockstream Green](https://github.com/Blockstream/green) in the future
 
 
 
 ### Signet Testing
 
-#### c-lightning
-For a c-lightning bitcoin-signetnet / liquid-testnet setup guide see this [guide](./docs/signetguide_clightning.md)
+#### core-lightning
+For a cpre-lightning bitcoin-signetnet / liquid-testnet setup guide see this [guide](./docs/signetguide_cln.md)
 
 #### lnd
 For a lnd bitcoin-signetnet / liquid-testnet setup guide see this [guide](./docs/signetguide_lnd.md)

--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -1,10 +1,10 @@
-# c-lightning Setup
+# core-lightning Setup
 
 This guide walks through the steps necessary to run the peerswap plugin on bitcoin signet and liquid testnet. This guide was written and tested under _Ubuntu-20.04_ but the same procedure also applies to different linux distributions.
 
 ## Install dependencies
 
-Peerswap requires [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/), [c-lightning](https://github.com/ElementsProject/lightning) and if the liquid testnet should be used also an _elementsd_ installation. If you already have all of these installed you can let them run in signet, or testnet mode and skip to the section about using the plugin.
+Peerswap requires [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/), [core-lightning](https://github.com/ElementsProject/lightning) and if the liquid testnet should be used also an _elementsd_ installation. If you already have all of these installed you can let them run in signet, or testnet mode and skip to the section about using the plugin.
 
 ## Peerswap
 
@@ -22,43 +22,47 @@ make cln-release
 
 The `peerswap` binary is now located in the repo folder.
 
-### Policy
 
-To ensure that only trusted nodes can send a peerswap request to your node it is optional to create a policy in the lightning config dir (default path: `~/.lightning/<network>/peerswap/policy.conf`) file in which the trusted nodes are specified. For every peer you want to allow swaps with, add a line with `allowlisted_peers=<REPLACE_WITH_PUBKEY_OF_PEER>`
 
-```bash
-cat <<EOF > ~/.lightning/mainnet>/peerswap/policy.conf
-allowlisted_peers=<REPLACE_WITH_PUBKEY_OF_PEER>
-allowlisted_peers=<REPLACE_WITH_PUBKEY_OF_PEER>
-EOF
-```
+## Config file
 
-## Run
+In order to run `peerswap` add following lines to your the core-lightning config file:
 
-In order to run `peerswap` start the c-lightning daemon with the following config flags replacing as needed.
-
-For bitcoin only:
 
 ```bash
-lightningd --daemon \
-        --plugin=$HOME/peerswap/peerswap 
+plugin=<LOCATION_TO_PEERSWAP-PLUGIN>
 ```
-Or with liquid enabled
+Peerswap will automatically try to connect to your bitcoind and (if available) elementsd
 
+The following optional configs can be specified:
 ```bash
-lightningd --daemon \
-        --plugin=$HOME/peerswap/peerswap \
-        --peerswap-liquid-rpchost=http://localhost \
-        --peerswap-liquid-rpcport=18884 \
-        --peerswap-liquid-rpcuser=<REPLACE_ME> \
-        --peerswap-liquid-rpcpassword=<REPLACE_ME> \
-        --peerswap-liquid-rpcwallet=swap 
+# General
+peerswap-db-path ## Path to swap db file (default: $HOME/.lightning/<network>/peerswap/swap)
+peerswap-policy-path ## Path to policy file (default: $HOME/.lightning/<network>/peerswap/policy.conf)
+
+# Bitcoin connection info 
+peerswap-bitcoin-rpchost ## Host of bitcoind rpc (default: localhost)
+peerswap-bitcoin-rpcport ## Port of bitcoind rpc (default: network-default)
+peerswap-bitcoin-rpcuser ## User for bitcoind rpc
+peerswap-bitcoin-rpcpassword ## Password for bitcoind rpc
+peerswap-bitcoin-cookiefilepath ## Path to bitcoin cookie file 
+
+peerswap-liquid-enabled ## Override liquid enable (default: true)
+peerswap-liquid-rpchost ## Host of elementsd rpc (default: localhost)
+peerswap-liquid-rpcport ## Port of elementsd rpc (default: 18888)
+peerswap-liquid-rpcuser ## User for elementsd rpc
+peerswap-liquid-rpcpassword ## Password for elementsd rpc
+peerswap-liquid-rpcpasswordfile ## Path to passwordfile for elementsd rpc
+peerswap-liquid-rpcwallet ## Rpcwallet to use (default: peerswap)
 ```
-
-__WARNING__: One could also set the `accept_all_peers=1` policy to ignore the allowlist and allow for all peers to send swap requests.
-
 
 In order to check if your daemon is setup correctly run
 ```bash
 lightning-cli peerswap-reloadpolicy
 ```
+
+### Policy
+
+On first startup of the plugin a policy file will be generated (default path: `~/.lightning/<network>/peerswap/policy.conf`) in which trusted nodes will be specified.
+This cann be done manually by adding a line with `allowlisted_peers=<REPLACE_WITH_PUBKEY_OF_PEER>` or with `lightning-cli peerswap-addpeer <PUBKEY>`. If you feel especially reckless you can add the line 
+`accept_all_peers=true` this will allow anyone with a direct channel to you do do a swap with you.

--- a/docs/signetguide_cln.md
+++ b/docs/signetguide_cln.md
@@ -4,7 +4,7 @@ This guide walks through the steps necessary to run the peerswap plugin on bitco
 
 ## Install dependencies
 
-Peerswap requires _clightning_, _bitcoind_ and if the liquid testnet should be used also an _elementsd_ installation. If you already have all of these installed you can let them run in signet, or testnet mode and skip to the section about using the plugin.
+Peerswap requires _core-lightning_, _bitcoind_ and if the liquid testnet should be used also an _elementsd_ installation. If you already have all of these installed you can let them run in signet, or testnet mode and skip to the section about using the plugin.
 
 ## Bitcoind (signet)
 
@@ -141,9 +141,9 @@ elements-cli getchaintips
 
 with the height of the last block on [liquid-testnet-explorer](https://liquidtestnet.com/explorer)
 
-## C-lightning
+## Core-lightning
 
-<!-- We need to build c-lightning ourselves to be able to be interoperable with lnd on signet -->
+<!-- We need to build cln ourselves to be able to be interoperable with lnd on signet -->
 
 get dependencies
 
@@ -226,7 +226,7 @@ rm SHA256SUMS.asc
 
 ### Run
 
-start the c-lightning daemon with the following config flags for bitcoin only:
+start the core-lightning daemon with the following config flags for bitcoin only:
 
 ```bash
 lightningd --daemon \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,16 +8,16 @@ PeerSwap is a Peer To Peer atomic swap plugin for lightning nodes. It allows for
 
 ## Notes on commands
 
-every command can be run with c-lightning plugins interface or using pscli.
+every command can be run with core-lightning plugins interface or using pscli.
 
-For the c-lightning plugin you need to prepend `lightning-cli peerswap-<command>`.
+For the cln plugin you need to prepend `lightning-cli peerswap-<command>`.
 
 For the standalone daemon you would run `pscli <command>`
 
 E.g. the `liquid-getaddress` command would look like this
 
 ```bash
-lightning-cli peerswap-liquid-getaddress ## c-lightning plugin call
+lightning-cli peerswap-liquid-getaddress ## cln plugin call
 pscli liquid-getaddress ## standalone daemon call
 ```
 
@@ -26,7 +26,7 @@ LND:
 
 ```pscli help```
 
-c-lightningplugin:
+core-lightning plugin:
 
 ```lightning-cli help | grep -A 1 peerswap```
 
@@ -64,7 +64,7 @@ swap-out [amount in sats] [short channel id] [asset: btc or l-brc]
 
 ### Swap-In
 
-A swap out is when the initiator wants to spend onchain bitcoin in order to receive lightning-funds, in channel balancing terms increasing outbound liquidity. In order to swap in you need to 
+A swap in is when the initiator wants to spend onchain bitcoin in order to receive lightning-funds, in channel balancing terms increasing outbound liquidity. In order to swap in you need to 
 
 To swap in call
 

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -275,7 +275,6 @@ func (d *dummyLightningClient) AddPaymentCallback(f func(string, InvoiceType)) {
 	d.paymentCallback = f
 }
 
-//todo implement
 func (d *dummyLightningClient) GetPayreq(msatAmount uint64, preimage string, swapId string, invoiceType InvoiceType, expiry uint64) (string, error) {
 	if d.preimage == "err" {
 		return "", errors.New("err")
@@ -319,7 +318,6 @@ func (d *dummyPolicy) IsPeerAllowed(peer string) bool {
 	return true
 }
 
-// todo implement
 func (d *dummyPolicy) GetMakerFee(swapValue uint64, swapFee uint64) (uint64, error) {
 	return 1, nil
 }

--- a/test/liquid_cln_test.go
+++ b/test/liquid_cln_test.go
@@ -767,7 +767,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 						lines: defaultLines,
 					},
 					tailableProcess{
-						p:      lightningds[0].(*testframework.CLightningNode).DaemonProcess,
+						p:      lightningds[0].(*CLightningNodeWithLiquid).DaemonProcess,
 						filter: filter,
 						lines:  defaultLines,
 					},
@@ -840,7 +840,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 						lines: defaultLines,
 					},
 					tailableProcess{
-						p:      lightningds[0].(*testframework.CLightningNode).DaemonProcess,
+						p:      lightningds[0].(*CLightningNodeWithLiquid).DaemonProcess,
 						filter: filter,
 						lines:  defaultLines,
 					},

--- a/test/setup.go
+++ b/test/setup.go
@@ -32,7 +32,7 @@ const (
 func clnclnSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
-	pathToPlugin := filepath.Join(filename, "..", "..", "out", "peerswap")
+	pathToPlugin := filepath.Join(filename, "..", "..", "out", "peerswap-plugin")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 2 lightningd)
@@ -49,6 +49,7 @@ func clnclnSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*t
 			t.Fatalf("could not create liquidd %v", err)
 		}
 		t.Cleanup(lightningd.Kill)
+		defer printFailedFiltered(t, lightningd.DaemonProcess)
 
 		// Create policy file and accept all peers
 		err = os.WriteFile(filepath.Join(lightningd.GetDataDir(), "..", "policy.conf"), []byte("accept_all_peers=1"), os.ModePerm)
@@ -135,6 +136,7 @@ func lndlndSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*t
 			t.Fatalf("could not create peerswapd %v", err)
 		}
 		t.Cleanup(peerswapd.Kill)
+		defer printFailed(t, lightningd.DaemonProcess)
 
 		peerswapds = append(peerswapds, peerswapd)
 	}
@@ -179,7 +181,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	peerswapdPath := filepath.Join(filename, "..", "..", "out", "peerswapd")
-	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "peerswap")
+	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "peerswap-plugin")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 cln, 1 lnd, 1 peerswapd)
@@ -195,6 +197,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 		t.Fatalf("could not create cln %v", err)
 	}
 	t.Cleanup(cln.Kill)
+	defer printFailedFiltered(t, cln.DaemonProcess)
 
 	// Create policy file and accept all peers
 	err = os.WriteFile(filepath.Join(cln.GetDataDir(), "..", "policy.conf"), []byte("accept_all_peers=1"), os.ModePerm)
@@ -226,6 +229,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 		t.Fatalf("could not create peerswapd %v", err)
 	}
 	t.Cleanup(peerswapd.Kill)
+	defer printFailed(t, peerswapd.DaemonProcess)
 
 	// Start nodes
 	err = bitcoind.Run(true)
@@ -279,7 +283,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, *testframework.LiquidNode, []*CLightningNodeWithLiquid, string) {
 	/// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
-	pathToPlugin := filepath.Join(filename, "..", "..", "out", "peerswap")
+	pathToPlugin := filepath.Join(filename, "..", "..", "out", "peerswap-plugin")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 liquidd, 2 lightningd)
@@ -303,6 +307,7 @@ func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 			t.Fatalf("could not create liquidd %v", err)
 		}
 		t.Cleanup(lightningd.Kill)
+		defer printFailedFiltered(t, lightningd.DaemonProcess)
 
 		// Create policy file and accept all peers
 		err = os.WriteFile(filepath.Join(lightningd.GetDataDir(), "..", "policy.conf"), []byte("accept_all_peers=1"), os.ModePerm)
@@ -420,6 +425,7 @@ func lndlndElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 			t.Fatalf("could not create liquidd %v", err)
 		}
 		t.Cleanup(lightningd.Kill)
+		defer printFailedFiltered(t, lightningd.DaemonProcess)
 
 		lightningds = append(lightningds, lightningd)
 	}
@@ -507,7 +513,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	peerswapdPath := filepath.Join(filename, "..", "..", "out", "peerswapd")
-	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "peerswap")
+	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "peerswap-plugin")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 liquid, 1 cln, 1 lnd, 1 peerswapd)
@@ -529,6 +535,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 		t.Fatalf("could not create cln %v", err)
 	}
 	t.Cleanup(cln.Kill)
+	defer printFailedFiltered(t, cln.DaemonProcess)
 
 	// Create policy file and accept all peers
 	err = os.WriteFile(filepath.Join(cln.GetDataDir(), "..", "policy.conf"), []byte("accept_all_peers=1"), os.ModePerm)
@@ -574,6 +581,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 		t.Fatalf("could not create peerswapd %v", err)
 	}
 	t.Cleanup(peerswapd.Kill)
+	defer printFailed(t, peerswapd.DaemonProcess)
 
 	// Start nodes
 	err = bitcoind.Run(true)

--- a/test/utils.go
+++ b/test/utils.go
@@ -44,6 +44,32 @@ func pprintFail(fps ...tailableProcess) {
 	}
 }
 
+func printFailedFiltered(t *testing.T, process *testframework.DaemonProcess) {
+	if t.Failed() {
+		filter := os.Getenv("PEERSWAP_TEST_FILTER")
+		pprintFail(
+			tailableProcess{
+				p:      process,
+				filter: filter,
+				lines:  defaultLines,
+			},
+		)
+	}
+}
+
+func printFailed(t *testing.T, process *testframework.DaemonProcess) {
+	if t.Failed() {
+		filter := os.Getenv("PEERSWAP_TEST_FILTER")
+		pprintFail(
+			tailableProcess{
+				p:      process,
+				filter: filter,
+				lines:  defaultLines,
+			},
+		)
+	}
+}
+
 type ChainNode interface {
 	GenerateBlocks(b int) error
 }

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -116,7 +116,7 @@ func NewCLightningNode(testDir string, bitcoin *BitcoinNode, id int) (*CLightnin
 func (n *CLightningNode) Run(waitForReady, waitForBitcoinSynced bool) error {
 	n.DaemonProcess.Run()
 	if waitForReady {
-		err := n.WaitForLog("Server started with public key", 60*time.Second)
+		err := n.WaitForLog("Server started with public key", TIMEOUT)
 		if err != nil {
 			return fmt.Errorf("CLightningNode.Run() %w", err)
 		}


### PR DESCRIPTION
This PR makes `peerswap-plugin` look for the liquid `.cookie` file in `$HOME/.elements/<network>/.cookie`.

Depending on the lightning network, the liquid network is chosen:
 - `mainnet`: `liquidv1`
 - `testnet`,`signet`: `liquidtestnet`
 - `regtest`:`liquidregtest`
 
This PR also fixes logs not showing in the github actions integration test