### PR TITLE
[FSM] fix print formatting, recovering of states

### DIFF
--- a/swap/actions.go
+++ b/swap/actions.go
@@ -729,7 +729,7 @@ func (c *CancelAction) Execute(services *SwapServices, swap *SwapData) EventType
 		swap.LastErrString = swap.LastErr.Error()
 	}
 
-	log.Infof("[Swap:%s] Swap canceled. Reason: ", swap.Id, swap.GetCancelMessage())
+	log.Infof("[Swap:%s] Swap canceled. Reason: %s", swap.Id, swap.GetCancelMessage())
 
 	return Event_Done
 }

--- a/swap/fsm.go
+++ b/swap/fsm.go
@@ -211,6 +211,7 @@ func (s *SwapStateMachine) SendEvent(event EventType, eventCtx EventContext) (bo
 
 // Recover tries to continue from the current state, by doing the associated Action
 func (s *SwapStateMachine) Recover() (bool, error) {
+	log.Infof("[Swap:%s]: Recovering from state %s", s.Id, s.Current)
 	state, ok := s.States[s.Current]
 	if !ok {
 		return false, fmt.Errorf("unknown state: %s for swap %s", s.Current, s.Id)
@@ -239,8 +240,12 @@ func (s *SwapStateMachine) Recover() (bool, error) {
 func (s *SwapStateMachine) IsFinished() bool {
 	switch s.Current {
 	case State_ClaimedCsv:
+		return true
 	case State_SwapCanceled:
+		return true
 	case State_ClaimedPreimage:
+		return true
+	case State_ClaimedCoop:
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR fixes some logging and a enum fallthrough bug

Closes #20