### PR TITLE
comment out potential source of error

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -535,6 +535,7 @@ func (cl *ClightningClient) RegisterMethods() error {
 			return err
 		}
 	}
+	/*
 	for _, v := range devmethods {
 		method := v.Get(cl)
 		glightningMethod := glightning.NewRpcMethod(method, "dev")
@@ -546,6 +547,7 @@ func (cl *ClightningClient) RegisterMethods() error {
 			return err
 		}
 	}
+	*/
 	return nil
 }
 


### PR DESCRIPTION
Updated to latest master, failed to start with this error being written
to the crash logs.

Commenting out this block "fixed" the problem.

```
2022/05/03 09:21:29 [INFO] plugin quitting, error: Method already registered
```