### PR TITLE
fix peerswap on testnet

### DIFF
--- a/swap/fsm.go
+++ b/swap/fsm.go
@@ -144,7 +144,7 @@ func (s *SwapStateMachine) SendEvent(event EventType, eventCtx EventContext) (bo
 		err = eventCtx.Validate(s.Data)
 		if err != nil {
 			s.mutex.Unlock()
-			log.Infof("Message validation error: %v", err)
+			log.Infof("Message validation error: %v on msg %v", err, eventCtx)
 			res, err := s.SendEvent(Event_OnInvalid_Message, nil)
 			s.mutex.Lock()
 			return res, err

--- a/swap/messages.go
+++ b/swap/messages.go
@@ -125,6 +125,8 @@ func validateNetwork(network string) error {
 		fallthrough
 	case "testnet":
 		fallthrough
+	case "testnet3":
+		fallthrough
 	case "signet":
 		fallthrough
 	case "regtest":


### PR DESCRIPTION
btcutil uses the name "testnet3" for testnet. Our message validator was only checking for "testnet"