### PR TITLE
remove redundant swapid in swap struct

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -354,8 +354,8 @@ func (l *SwapIn) Call() (jrpc2.Result, error) {
 
 // ListSwaps list all active and finished swaps
 type ListSwaps struct {
-	PrettyPrint bool              `json:"pretty_print,omitempty"`
-	cl          *ClightningClient `json:"-"`
+	DetailedPrint bool              `json:"detailed,omitempty"`
+	cl            *ClightningClient `json:"-"`
 }
 
 func (l *ListSwaps) New() interface{} {
@@ -379,7 +379,7 @@ func (l *ListSwaps) Call() (jrpc2.Result, error) {
 		}
 		return false
 	})
-	if l.PrettyPrint {
+	if !l.DetailedPrint {
 		var pswasp []*swap.PrettyPrintSwapData
 		for _, v := range swaps {
 			if v.Data == nil {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,7 @@ Example output:
 ]
 ```
 
-`listswaps [pretty bool (optional)]` - command that lists all swaps. If _pretty_ is set the output is in a human readable format
+`listswaps [detailed bool (optional)]` - command that lists all swaps. If _detailed_ is set the output shows the swap data as it is saved in the database
 
 `listactiveswaps` - list all ongoing swaps, relevant for upgrading peerswap
 

--- a/peerswaprpc/server.go
+++ b/peerswaprpc/server.go
@@ -530,7 +530,7 @@ func (p *PeerswapServer) AllowSwapRequests(ctx context.Context, request *AllowSw
 func PrettyprintFromServiceSwap(swap *swap.SwapStateMachine) *PrettyPrintSwap {
 	timeStamp := time.Unix(swap.Data.CreatedAt, 0)
 	return &PrettyPrintSwap{
-		Id:              swap.Id,
+		Id:              swap.SwapId.String(),
 		CreatedAt:       timeStamp.String(),
 		Type:            swap.Type.String(),
 		Role:            swap.Role.String(),

--- a/swap/fsm.go
+++ b/swap/fsm.go
@@ -67,7 +67,6 @@ type States map[StateType]State
 // SwapStateMachine represents the state machine.
 type SwapStateMachine struct {
 	// Id holds the unique Id for the store
-	Id     string  `json:"id"`
 	SwapId *SwapId `json:"swap_id"`
 
 	// Data holds the statemachine metadata
@@ -162,7 +161,7 @@ func (s *SwapStateMachine) SendEvent(event EventType, eventCtx EventContext) (bo
 
 	for {
 		// Determine the next state for the event given the machine's current state.
-		log.Debugf("[FSM] event:id: %s, %s on %s", s.Id, event, s.Current)
+		log.Debugf("[FSM] event:id: %s, %s on %s", s.SwapId.String(), event, s.Current)
 		nextState, err := s.getNextState(event)
 		if err != nil {
 			return false, ErrEventRejected
@@ -214,10 +213,10 @@ func (s *SwapStateMachine) SendEvent(event EventType, eventCtx EventContext) (bo
 
 // Recover tries to continue from the current state, by doing the associated Action
 func (s *SwapStateMachine) Recover() (bool, error) {
-	log.Infof("[Swap:%s]: Recovering from state %s", s.Id, s.Current)
+	log.Infof("[Swap:%s]: Recovering from state %s", s.SwapId.String(), s.Current)
 	state, ok := s.States[s.Current]
 	if !ok {
-		return false, fmt.Errorf("unknown state: %s for swap %s", s.Current, s.Id)
+		return false, fmt.Errorf("unknown state: %s for swap %s", s.Current, s.SwapId.String())
 	}
 
 	if !ok || state.Action == nil {
@@ -302,6 +301,6 @@ func (s *SwapStateMachine) logSwapInfo() {
 }
 
 func (s *SwapStateMachine) Infof(format string, v ...interface{}) {
-	idString := fmt.Sprintf("%s", s.Id)
+	idString := fmt.Sprintf("%s", s.SwapId.String())
 	log.Infof("[Swap:"+idString+"] "+format, v...)
 }

--- a/swap/service.go
+++ b/swap/service.go
@@ -115,7 +115,7 @@ func (s *SwapService) RecoverSwaps() error {
 			swap = swapOutReceiverFromStore(swap, s.swapServices)
 		}
 
-		s.AddActiveSwap(swap.Id, swap)
+		s.AddActiveSwap(swap.SwapId.String(), swap)
 
 		done, err := swap.Recover()
 		if err != nil {
@@ -123,7 +123,7 @@ func (s *SwapService) RecoverSwaps() error {
 		}
 
 		if done {
-			s.RemoveActiveSwap(swap.Id)
+			s.RemoveActiveSwap(swap.SwapId.String())
 		}
 	}
 	return nil
@@ -283,7 +283,7 @@ func (s *SwapService) OnTxConfirmed(swapId string, txHex string) error {
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -301,7 +301,7 @@ func (s *SwapService) OnCsvPassed(swapId string) error {
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -322,7 +322,7 @@ func (s *SwapService) SwapOut(peer string, chain string, channelId string, initi
 	}
 
 	swap := newSwapOutSenderFSM(s.swapServices, initiator, peer)
-	s.AddActiveSwap(swap.Id, swap)
+	s.AddActiveSwap(swap.SwapId.String(), swap)
 
 	var bitcoinNetwork string
 	var elementsAsset string
@@ -349,7 +349,7 @@ func (s *SwapService) SwapOut(peer string, chain string, channelId string, initi
 		return nil, err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 
 	return swap, nil
@@ -379,7 +379,7 @@ func (s *SwapService) SwapIn(peer string, chain string, channelId string, initia
 		return nil, errors.New("invalid chain")
 	}
 	swap := newSwapInSenderFSM(s.swapServices, initiator, peer)
-	s.AddActiveSwap(swap.Id, swap)
+	s.AddActiveSwap(swap.SwapId.String(), swap)
 
 	request := &SwapInRequestMessage{
 		ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
@@ -396,7 +396,7 @@ func (s *SwapService) SwapIn(peer string, chain string, channelId string, initia
 		return nil, err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return swap, nil
 }
@@ -416,7 +416,7 @@ func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, mes
 
 	done, err := swap.SendEvent(Event_SwapInReceiver_OnRequestReceived, message)
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return err
 }
@@ -440,7 +440,7 @@ func (s *SwapService) OnSwapOutRequestReceived(swapId *SwapId, peerId string, me
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -457,7 +457,7 @@ func (s *SwapService) OnSwapInAgreementReceived(msg *SwapInAgreementMessage) err
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -474,7 +474,7 @@ func (s *SwapService) OnSwapOutAgreementReceived(message *SwapOutAgreementMessag
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -492,7 +492,7 @@ func (s *SwapService) OnFeeInvoiceNotification(swapId *SwapId) error {
 	}
 
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -509,7 +509,7 @@ func (s *SwapService) OnClaimInvoiceNotification(swapId *SwapId) error {
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -526,7 +526,7 @@ func (s *SwapService) OnTxOpenedMessage(message *OpeningTxBroadcastedMessage) er
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -542,9 +542,9 @@ func (s *SwapService) SenderOnTxConfirmed(swapId string) error {
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
-	s.RemoveActiveSwap(swap.Id)
+	s.RemoveActiveSwap(swap.SwapId.String())
 	return nil
 }
 
@@ -596,7 +596,7 @@ func (s *SwapService) OnCancelReceived(swapId *SwapId, cancelMsg *CancelMessage)
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -613,7 +613,7 @@ func (s *SwapService) OnCoopCloseReceived(swapId *SwapId, coopCloseMessage *Coop
 		return err
 	}
 	if done {
-		s.RemoveActiveSwap(swap.Id)
+		s.RemoveActiveSwap(swap.SwapId.String())
 	}
 	return nil
 }
@@ -750,7 +750,7 @@ func (s *SwapService) createTimeoutCallback(swapId string) func() {
 		}
 
 		if done {
-			s.RemoveActiveSwap(swap.Id)
+			s.RemoveActiveSwap(swap.SwapId.String())
 		}
 	}
 }

--- a/swap/store.go
+++ b/swap/store.go
@@ -63,7 +63,7 @@ func (p *bboltStore) GetData(id string) (*SwapStateMachine, error) {
 }
 
 func (p *bboltStore) Create(swap *SwapStateMachine) error {
-	exists, err := p.idExists(swap.Id)
+	exists, err := p.idExists(swap.SwapId.String())
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p *bboltStore) Create(swap *SwapStateMachine) error {
 		return err
 	}
 
-	if err := b.Put(h2b(swap.Id), jData); err != nil {
+	if err := b.Put(h2b(swap.SwapId.String()), jData); err != nil {
 		return err
 	}
 
@@ -95,7 +95,7 @@ func (p *bboltStore) Create(swap *SwapStateMachine) error {
 }
 
 func (p *bboltStore) Update(swap *SwapStateMachine) error {
-	exists, err := p.idExists(swap.Id)
+	exists, err := p.idExists(swap.SwapId.String())
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (p *bboltStore) Update(swap *SwapStateMachine) error {
 		return err
 	}
 
-	if err := b.Put(h2b(swap.Id), jData); err != nil {
+	if err := b.Put(h2b(swap.SwapId.String()), jData); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -341,7 +341,7 @@ func (s *SwapData) GetCancelMessage() string {
 		return s.CancelMessage
 	}
 
-	return "unknown"
+	return ""
 }
 
 func (s *SwapData) cancelTimeout() {
@@ -352,6 +352,7 @@ func (s *SwapData) cancelTimeout() {
 
 type PrettyPrintSwapData struct {
 	Id              string `json:"id"`
+	Asset           string `json:"asset"`
 	CreatedAt       string `json:"created_at"`
 	Type            string `json:"type"`
 	Role            string `json:"role"`
@@ -370,32 +371,21 @@ type PrettyPrintSwapData struct {
 
 func (s *SwapData) ToPrettyPrint() *PrettyPrintSwapData {
 	timeStamp := time.Unix(s.CreatedAt, 0)
-	if s.LastErr != nil {
-		s.LastErrString = s.LastErr.Error()
-	}
-	var scid string
-	var amount uint64
-	if s.SwapInRequest != nil {
-		scid = s.SwapInRequest.Scid
-		amount = s.SwapInRequest.Amount
-	}
-	if s.SwapOutRequest != nil {
-		scid = s.SwapOutRequest.Scid
-		amount = s.SwapOutRequest.Amount
-	}
+
 	return &PrettyPrintSwapData{
 		Id:              s.GetId().String(),
+		Asset:           s.GetChain(),
 		Type:            s.GetType().String(),
 		Role:            s.Role.String(),
 		State:           string(s.FSMState),
 		InitiatorNodeId: s.InitiatorNodeId,
 		PeerNodeId:      s.PeerNodeId,
-		Amount:          amount,
-		ShortChannelId:  scid,
+		Amount:          s.GetAmount(),
+		ShortChannelId:  s.GetScid(),
 		OpeningTxId:     s.GetOpeningTxId(),
 		ClaimTxId:       s.ClaimTxId,
 		CreatedAt:       timeStamp.String(),
-		CancelMessage:   s.LastErrString,
+		CancelMessage:   s.GetCancelMessage(),
 	}
 }
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -83,8 +83,6 @@ func (i InvoiceType) String() string {
 
 // SwapData holds all the data needed for a swap
 type SwapData struct {
-	Id *SwapId `json:"id"`
-
 	// Swap In
 	SwapInRequest   *SwapInRequestMessage   `json:"swap_in_request"`
 	SwapInAgreement *SwapInAgreementMessage `json:"swap_in_agreement"`
@@ -135,7 +133,19 @@ type SwapData struct {
 }
 
 func (s *SwapData) GetId() *SwapId {
-	return s.Id
+	if s.SwapInRequest != nil {
+		return s.SwapInRequest.SwapId
+	}
+	if s.SwapOutRequest != nil {
+		return s.SwapOutRequest.SwapId
+	}
+	if s.SwapInAgreement != nil {
+		return s.SwapInAgreement.SwapId
+	}
+	if s.SwapOutAgreement != nil {
+		return s.SwapOutAgreement.SwapId
+	}
+	return nil
 }
 
 func (s *SwapData) GetProtocolVersion() uint8 {
@@ -374,7 +384,7 @@ func (s *SwapData) ToPrettyPrint() *PrettyPrintSwapData {
 		amount = s.SwapOutRequest.Amount
 	}
 	return &PrettyPrintSwapData{
-		Id:              s.Id.String(),
+		Id:              s.GetId().String(),
 		Type:            s.GetType().String(),
 		Role:            s.Role.String(),
 		State:           string(s.FSMState),
@@ -397,7 +407,6 @@ func (s *SwapData) GetPrivkey() *btcec.PrivateKey {
 // NewSwapData returns a new swap with a random hex id and the given arguments
 func NewSwapData(swapId *SwapId, initiatorNodeId string, peerNodeId string) *SwapData {
 	return &SwapData{
-		Id:              swapId,
 		PeerNodeId:      peerNodeId,
 		InitiatorNodeId: initiatorNodeId,
 		PrivkeyBytes:    getRandomPrivkey().Serialize(),
@@ -409,7 +418,6 @@ func NewSwapData(swapId *SwapId, initiatorNodeId string, peerNodeId string) *Swa
 // NewSwapDataFromRequest returns a new swap created from a swap request
 func NewSwapDataFromRequest(swapId *SwapId, senderNodeId string) *SwapData {
 	return &SwapData{
-		Id:              swapId,
 		PeerNodeId:      senderNodeId,
 		InitiatorNodeId: senderNodeId,
 		CreatedAt:       time.Now().Unix(),
@@ -443,6 +451,9 @@ func NewSwapId() *SwapId {
 }
 
 func (s *SwapId) String() string {
+	if s == nil || len(s) == 0 {
+		return ""
+	}
 	return hex.EncodeToString(s[:])
 }
 

--- a/swap/swap_in_receiver.go
+++ b/swap/swap_in_receiver.go
@@ -10,7 +10,6 @@ func swapInReceiverFromStore(smData *SwapStateMachine, services *SwapServices) *
 // newSwapInReceiverFSM returns a new swap statemachine for a swap-in receiver
 func newSwapInReceiverFSM(swapId *SwapId, services *SwapServices, peer string) *SwapStateMachine {
 	return &SwapStateMachine{
-		Id:           swapId.String(),
 		SwapId:       swapId,
 		swapServices: services,
 		Type:         SWAPTYPE_IN,

--- a/swap/swap_in_sender.go
+++ b/swap/swap_in_sender.go
@@ -11,7 +11,6 @@ func swapInSenderFromStore(smData *SwapStateMachine, services *SwapServices) *Sw
 func newSwapInSenderFSM(services *SwapServices, initiatorNodeId, peerNodeId string) *SwapStateMachine {
 	swapId := NewSwapId()
 	return &SwapStateMachine{
-		Id:           swapId.String(),
 		SwapId:       swapId,
 		swapServices: services,
 		Type:         SWAPTYPE_IN,

--- a/swap/swap_out_receiver.go
+++ b/swap/swap_out_receiver.go
@@ -14,7 +14,6 @@ func swapOutReceiverFromStore(smData *SwapStateMachine, services *SwapServices) 
 // newSwapOutReceiverFSM returns a new swap statemachine for a swap-out receiver
 func newSwapOutReceiverFSM(swapId *SwapId, services *SwapServices, peer string) *SwapStateMachine {
 	return &SwapStateMachine{
-		Id:           swapId.String(),
 		SwapId:       swapId,
 		swapServices: services,
 		Type:         SWAPTYPE_OUT,

--- a/swap/swap_out_sender.go
+++ b/swap/swap_out_sender.go
@@ -11,7 +11,6 @@ func swapOutSenderFromStore(smData *SwapStateMachine, services *SwapServices) *S
 func newSwapOutSenderFSM(services *SwapServices, initiatorNodeId, peerNodeId string) *SwapStateMachine {
 	swapId := NewSwapId()
 	return &SwapStateMachine{
-		Id:           swapId.String(),
 		SwapId:       swapId,
 		swapServices: services,
 		Type:         SWAPTYPE_OUT,

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -14,7 +14,7 @@ func Test_SwapMarshalling(t *testing.T) {
 	swap := newSwapOutSenderFSM(&SwapServices{}, "alice", "bob")
 
 	swap.Data = &SwapData{
-		Id: NewSwapId(),
+		SwapOutRequest: &SwapOutRequestMessage{SwapId: NewSwapId()},
 	}
 
 	swapBytes, err := json.Marshal(swap)
@@ -28,7 +28,7 @@ func Test_SwapMarshalling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, swap.Data.GetId(), sm.Data.Id)
+	assert.Equal(t, swap.Data.GetId(), sm.Data.GetId())
 }
 
 func Test_ValidSwap(t *testing.T) {
@@ -216,7 +216,7 @@ func (d *dummyStore) ListAllByPeer(peer string) ([]*SwapStateMachine, error) {
 }
 
 func (d *dummyStore) UpdateData(data *SwapStateMachine) error {
-	d.dataMap[data.Id] = data
+	d.dataMap[data.SwapId.String()] = data
 	return nil
 }
 


### PR DESCRIPTION
This PR removes the multiple appearances of `swap_id` in the json response. It also reverses the bool for pretty_print

closes #48 