### PR TITLE
change liquid target blocks

### DIFF
--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -30,7 +30,7 @@ import (
 const (
 	LiquidCsv          = 60
 	LiquidConfs        = 2
-	LiquidTargetBlocks = 1
+	LiquidTargetBlocks = 7
 )
 
 type LiquidOnChain struct {


### PR DESCRIPTION
This PR changes the target blocks for the liquid fee estimator from 1 to 7 for this arbitrary reason:

![image](https://user-images.githubusercontent.com/8904314/167637934-06a6a6e2-8675-43e1-93bd-a4b6d56cda14.png)
