### PR TITLE
Fix high cpu load

### DIFF
--- a/txwatcher/rpctxwatcher.go
+++ b/txwatcher/rpctxwatcher.go
@@ -104,7 +104,7 @@ func (s *BlockchainRpcTxWatcher) StartWatchingTxs() error {
 					return err
 				}
 			default:
-				time.Sleep(time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 	}()


### PR DESCRIPTION
Seems the tx watcher was the problem here. We need to wait longer between the calls to the bitcoin backend in
order to avoid high cpu loads.