### PR TITLE
Fix broken MPPs for large cln payments

### DIFF
--- a/clightning/clightning_test.go
+++ b/clightning/clightning_test.go
@@ -105,3 +105,11 @@ func (d *DummyPayerWaiter) SendPayChannel(payreq string, bolt11 *glightning.Deco
 	d.totalPayed += amountMsat
 	return "", d.sendPayError
 }
+
+func (d *DummyPayerWaiter) SendPart(payreq string, bolt11 *glightning.DecodedBolt11, amountMsat uint64, channel string, label string, partId uint64) (*glightning.SendPayFields, error) {
+	d.Lock()
+	defer d.Unlock()
+	d.sendPayCall++
+	d.totalPayed += amountMsat
+	return &glightning.SendPayFields{}, d.sendPayError
+}

--- a/clightning/clightning_test.go
+++ b/clightning/clightning_test.go
@@ -16,19 +16,17 @@ func Test_MppPayments(t *testing.T) {
 
 	paymentSize := uint64(5100000 * 1000)
 	noErrorPayer := &DummyPayerWaiter{
-		waitSendPayError: nil,
-		waitSendPayRes: &glightning.SendPayFields{
+		sendPayPartsAndWaitErrorReturn: nil,
+		sendPayPartsAndWaitReturn: &glightning.SendPayFields{
 			PaymentPreimage: "preimage",
 		},
-		sendPayError: nil,
 	}
-	preimage, err := MppPayment(noErrorPayer, noErrorPayer, "", "", &glightning.DecodedBolt11{
+	preimage, err := MppPayment(noErrorPayer, "", "", &glightning.DecodedBolt11{
 		MilliSatoshis: paymentSize,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "preimage", preimage)
-	assert.Equal(t, 6, noErrorPayer.sendPayCall)
-	assert.Equal(t, 6, noErrorPayer.waitSendCalls)
+	assert.Equal(t, 10, noErrorPayer.sendPayPartsAndWaitCalled)
 	assert.Equal(t, paymentSize, noErrorPayer.totalPayed)
 }
 
@@ -38,20 +36,18 @@ func Test_MppPaymentsError1(t *testing.T) {
 	paymentSize := uint64(5100000 * 1000)
 	sendpayError := errors.New("sendpay error")
 	noErrorPayer := &DummyPayerWaiter{
-		waitSendPayError: nil,
-		waitSendPayRes: &glightning.SendPayFields{
+		sendPayPartsAndWaitErrorReturn: &sendpayError,
+		sendPayPartsAndWaitReturn: &glightning.SendPayFields{
 			PaymentPreimage: "preimage",
 		},
-		sendPayError: sendpayError,
 	}
-	preimage, err := MppPayment(noErrorPayer, noErrorPayer, "", "", &glightning.DecodedBolt11{
+	preimage, err := MppPayment(noErrorPayer, "", "", &glightning.DecodedBolt11{
 		MilliSatoshis: paymentSize,
 	})
 	assert.Error(t, err)
 	assert.Equal(t, "", preimage)
-	assert.Equal(t, 1, noErrorPayer.sendPayCall)
-	assert.Equal(t, 0, noErrorPayer.waitSendCalls)
-	assert.Equal(t, uint64(1000000*1000), noErrorPayer.totalPayed)
+	assert.Equal(t, 10, noErrorPayer.sendPayPartsAndWaitCalled)
+	assert.EqualValues(t, uint64(5100000*1000), noErrorPayer.totalPayed)
 }
 
 func Test_MppPaymentsError2(t *testing.T) {
@@ -61,55 +57,39 @@ func Test_MppPaymentsError2(t *testing.T) {
 
 	waitSendError := errors.New("sendpay error")
 	noErrorPayer := &DummyPayerWaiter{
-		waitSendPayError: waitSendError,
-		waitSendPayRes: &glightning.SendPayFields{
+		sendPayPartsAndWaitErrorReturn: &waitSendError,
+		sendPayPartsAndWaitReturn: &glightning.SendPayFields{
 			PaymentPreimage: "preimage",
 		},
-		sendPayError: nil,
 	}
-	preimage, err := MppPayment(noErrorPayer, noErrorPayer, "", "", &glightning.DecodedBolt11{
+	preimage, err := MppPayment(noErrorPayer, "", "", &glightning.DecodedBolt11{
 		MilliSatoshis: paymentSize,
 	})
 	assert.Error(t, err)
 	assert.Equal(t, "", preimage)
-	assert.Equal(t, 6, noErrorPayer.sendPayCall)
-	assert.Equal(t, 6, noErrorPayer.waitSendCalls)
+	assert.Equal(t, 10, noErrorPayer.sendPayPartsAndWaitCalled)
 	assert.Equal(t, paymentSize, noErrorPayer.totalPayed)
 }
 
 type DummyPayerWaiter struct {
-	waitSendPayError error
-	waitSendCalls    int
-	waitSendPayRes   *glightning.SendPayFields
+	sync.Mutex
 
-	sendPayError error
-	sendPayCall  int
+	sendPayPartsAndWaitCalled      int
+	sendPayPartsAndWaitReturn      *glightning.SendPayFields
+	sendPayPartsAndWaitErrorReturn *error
 
 	totalPayed uint64
-
-	sync.Mutex
 }
 
-func (d *DummyPayerWaiter) WaitSendPayPart(paymentHash string, timeout uint, partId uint64) (*glightning.SendPayFields, error) {
-	time.Sleep(time.Second * time.Duration(rand.Intn(5)))
+func (d *DummyPayerWaiter) SendPayPartAndWait(paymentRequest string, bolt11 *glightning.DecodedBolt11, amountMsat uint64, channel string, label string, partId uint64) (*glightning.SendPayFields, error) {
 	d.Lock()
 	defer d.Unlock()
-	d.waitSendCalls++
-	return d.waitSendPayRes, d.waitSendPayError
-}
-
-func (d *DummyPayerWaiter) SendPayChannel(payreq string, bolt11 *glightning.DecodedBolt11, amountMsat uint64, channel string, label string, partId uint64) (string, error) {
-	d.Lock()
-	defer d.Unlock()
-	d.sendPayCall++
+	d.sendPayPartsAndWaitCalled++
 	d.totalPayed += amountMsat
-	return "", d.sendPayError
-}
 
-func (d *DummyPayerWaiter) SendPart(payreq string, bolt11 *glightning.DecodedBolt11, amountMsat uint64, channel string, label string, partId uint64) (*glightning.SendPayFields, error) {
-	d.Lock()
-	defer d.Unlock()
-	d.sendPayCall++
-	d.totalPayed += amountMsat
-	return &glightning.SendPayFields{}, d.sendPayError
+	if d.sendPayPartsAndWaitErrorReturn != nil {
+		return nil, *d.sendPayPartsAndWaitErrorReturn
+	}
+
+	return d.sendPayPartsAndWaitReturn, nil
 }

--- a/test/mpp_test.go
+++ b/test/mpp_test.go
@@ -1,0 +1,193 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/elementsproject/peerswap/clightning"
+	"github.com/elementsproject/peerswap/swap"
+	"github.com/elementsproject/peerswap/testframework"
+	"github.com/stretchr/testify/require"
+)
+
+const maxChanSize uint64 = 16777215
+
+// Max payment size is 2^32 msat
+const maxPaymentSize uint64 = 4294967
+
+// Test_ClnCln_MPP tests the correctness of MPP if the size of a payment exceed
+// the maximum size of a single payment between two cln nodes. It is sufficcient
+// to only test on Bitcoin Regtest and only test for swap in cases, as all other
+// ways share the same MPP splitter.
+func Test_ClnCln_MPP(t *testing.T) {
+	tests := []struct {
+		description   string
+		swapAmountSat uint64
+	}{
+		{description: "in max size no mpp", swapAmountSat: maxPaymentSize},
+		{description: "in min size mpp", swapAmountSat: maxPaymentSize + 1},
+		// Default assumption is that 1% of the channel size is kept as a
+		// reserve on both sides (see bolt #2).
+		{description: "in max size mpp", swapAmountSat: maxChanSize - 2*((maxChanSize/100)+1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+
+			// We use a higher amount to check if MPP splitting is done
+			// correctly. This is the max capacity of a standart channel
+			// (not large).
+			bitcoind, lightningds, scid := clnclnSetup(t, maxChanSize)
+			defer func() {
+				if t.Failed() {
+					filter := os.Getenv("PEERSWAP_TEST_FILTER")
+					pprintFail(
+						tailableProcess{
+							p:     bitcoind.DaemonProcess,
+							lines: defaultLines,
+						},
+						tailableProcess{
+							p:      lightningds[0].DaemonProcess,
+							filter: filter,
+							lines:  defaultLines,
+						},
+						tailableProcess{
+							p:      lightningds[1].DaemonProcess,
+							filter: filter,
+							lines:  defaultLines,
+						},
+					)
+				}
+			}()
+
+			var channelBalances []uint64
+			var walletBalances []uint64
+			for _, lightningd := range lightningds {
+				b, err := lightningd.GetBtcBalanceSat()
+				require.NoError(err)
+				walletBalances = append(walletBalances, b)
+
+				b, err = lightningd.GetChannelBalanceSat(scid)
+				require.NoError(err)
+				channelBalances = append(channelBalances, b)
+			}
+
+			params := &testParams{
+				swapAmt:          tt.swapAmountSat,
+				scid:             scid,
+				origTakerWallet:  walletBalances[0],
+				origMakerWallet:  walletBalances[1],
+				origTakerBalance: channelBalances[0],
+				origMakerBalance: channelBalances[1],
+				takerNode:        lightningds[0],
+				makerNode:        lightningds[1],
+				takerPeerswap:    lightningds[0].DaemonProcess,
+				makerPeerswap:    lightningds[1].DaemonProcess,
+				chainRpc:         bitcoind.RpcProxy,
+				chaind:           bitcoind,
+				confirms:         BitcoinConfirms,
+				csv:              BitcoinCsv,
+				swapType:         swap.SWAPTYPE_IN,
+			}
+			asset := "btc"
+
+			// Do swap.
+			go func() {
+				var response map[string]interface{}
+				lightningds[1].Rpc.Request(&clightning.SwapIn{SatAmt: params.swapAmt, ShortChannelId: params.scid, Asset: asset}, &response)
+			}()
+			preimageClaimTest(t, params)
+		})
+	}
+}
+
+// Test_ClnLnd_MPP tests the correctness of MPP if the size of a payment exceed
+// the maximum size of a single payment from a requesting cln node. It is
+// sufficcient to only test on Bitcoin Regtest and only test for swap in cases,
+// as all other ways share the same MPP splitter.
+func Test_ClnLnd_MPP(t *testing.T) {
+	tests := []struct {
+		description   string
+		swapAmountSat uint64
+	}{
+		{description: "in max size no mpp", swapAmountSat: maxPaymentSize},
+		{description: "in min size mpp", swapAmountSat: maxPaymentSize + 1},
+		// Default assumption is that 1% of the channel size is kept as a
+		// reserve on both sides (see bolt #2).
+		{description: "in max size mpp", swapAmountSat: maxChanSize - 2*((maxChanSize/100)+1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+
+			bitcoind, lightningds, peerswapd, scid := mixedSetup(t, maxChanSize, FUNDER_LND)
+			defer func() {
+				if t.Failed() {
+					filter := os.Getenv("PEERSWAP_TEST_FILTER")
+					pprintFail(
+						tailableProcess{
+							p:     bitcoind.DaemonProcess,
+							lines: defaultLines,
+						},
+						tailableProcess{
+							p:     lightningds[0].(*testframework.LndNode).DaemonProcess,
+							lines: defaultLines,
+						},
+						tailableProcess{
+							p:      lightningds[1].(*testframework.CLightningNode).DaemonProcess,
+							filter: filter,
+							lines:  defaultLines,
+						},
+						tailableProcess{
+							p:     peerswapd.DaemonProcess,
+							lines: defaultLines,
+						},
+					)
+				}
+			}()
+
+			var channelBalances []uint64
+			var walletBalances []uint64
+			for _, lightningd := range lightningds {
+				b, err := lightningd.GetBtcBalanceSat()
+				require.NoError(err)
+				walletBalances = append(walletBalances, b)
+
+				b, err = lightningd.GetChannelBalanceSat(scid)
+				require.NoError(err)
+				channelBalances = append(channelBalances, b)
+			}
+
+			params := &testParams{
+				swapAmt:          tt.swapAmountSat,
+				scid:             scid,
+				origTakerWallet:  walletBalances[0],
+				origMakerWallet:  walletBalances[1],
+				origTakerBalance: channelBalances[0],
+				origMakerBalance: channelBalances[1],
+				takerNode:        lightningds[0],
+				makerNode:        lightningds[1],
+				takerPeerswap:    peerswapd.DaemonProcess,
+				makerPeerswap:    lightningds[1].(*testframework.CLightningNode).DaemonProcess,
+				chainRpc:         bitcoind.RpcProxy,
+				chaind:           bitcoind,
+				confirms:         BitcoinConfirms,
+				csv:              BitcoinCsv,
+				swapType:         swap.SWAPTYPE_IN,
+			}
+			asset := "btc"
+
+			// Do swap.
+			go func() {
+				// We need to run this in a go routine as the Request call is blocking and sometimes does not return.
+				var response map[string]interface{}
+				lightningds[1].(*testframework.CLightningNode).Rpc.Request(&clightning.SwapIn{SatAmt: params.swapAmt, ShortChannelId: params.scid, Asset: asset}, &response)
+			}()
+			preimageClaimTest(t, params)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes an issue with large swaps where the cln node is the payer. If a payment exceeds the size of 2^32 msat we need to split it up according to cln MPP rules. One of these rules is, that every payment part has to have the exact same size in msat. This PR fixes the peerswap MPP splitter that used to divide in fixed parts with a rest.

Also adds some tests for MPPs.

Please do not merge directly after review, I will squash the fixups first!