### PR TITLE
Fix clone command in CLN and LND setup guides.

### DIFF
--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -15,7 +15,7 @@ Install golang from https://golang.org/doc/install
 Clone into the peerswap repository and build the peerswap plugin
 
 ```bash
-git clone git@github.com:sputn1ck/peerswap.git && \
+git clone https://github.com/ElementsProject/peerswap.git && \
 cd peerswap && \
 make cln-release
 ```

--- a/docs/setup_lnd.md
+++ b/docs/setup_lnd.md
@@ -15,7 +15,7 @@ Install golang from https://golang.org/doc/install
 Clone the peerswap repository and build the peerswap plugin
 
 ```bash
-git clone git@github.com:elementsproject/peerswap.git && \
+git clone https://github.com/ElementsProject/peerswap.git && \
 cd peerswap && \
 make lnd-install
 ```


### PR DESCRIPTION
Summary of changes:
1. Changes CLN setup guide to clone from `ElementsProject` repo instead of `sputn1k`.
1. Changes both guides to clone using HTTPS instead of SSH.

Using HTTPS works in more situations since a user doesn't need to setup an Github user and SSH key prior to cloning.