### PR TITLE
Fix lnd payment notifier

### DIFF
--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -80,22 +80,14 @@ func (l *Lnd) AddPaymentNotifier(swapId string, payreq string, invoiceType swap.
 		log.Infof("decode invoice error")
 		return false
 	}
+
 	rHash, err := hex.DecodeString(invoice.PaymentHash)
 	if err != nil {
 		log.Infof("decode rhash error")
 		return false
 	}
-	lookup, err := l.lndClient.LookupInvoice(l.ctx, &lnrpc.PaymentHash{RHash: rHash})
-	if err != nil && (lookup.State == lnrpc.Invoice_SETTLED && lookup.AmtPaidSat == invoice.NumSatoshis) {
-		return true
-	}
-	// Check if service is already subscribed
-	if HasInvoiceSubscribtion(l.invoiceSubscriptions, invoice.PaymentHash) {
-		return false
-	}
 
 	go func() {
-
 		// add subscribtion
 		AddInvoiceSubscription(l, l.invoiceSubscriptions, invoice.PaymentHash)
 		defer RemoveInvoiceSubscribtion(l, l.invoiceSubscriptions, invoice.PaymentHash)

--- a/lnd/lnd_test.go
+++ b/lnd/lnd_test.go
@@ -51,6 +51,10 @@ func (t *Testthing) callback(swapId string) error {
 }
 
 func Test_LndClightningPayments(t *testing.T) {
+	// NOTE: It seems that this tests a basic lightning
+	// invoice payment be a cln node to a lnd node. Is this really something
+	// we need to test?
+	// -> This should be removed I guess.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -244,6 +248,7 @@ loop:
 	log.Printf("spending txid: %s", spendingTxId)
 
 }
+
 func Test_LndSystemsCsv(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -350,6 +355,9 @@ loop:
 }
 
 func Test_Lnd(t *testing.T) {
+	// NOTE: Can we remove the comments from this function? If yes, please do
+	// so.
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -537,6 +545,7 @@ func Test_Lnd(t *testing.T) {
 	//spendingTxHex := hex.EncodeToString(bytesBuffer.Bytes())
 
 }
+
 func Test_FeeBump(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -563,7 +572,11 @@ func Test_FeeBump(t *testing.T) {
 	})
 	log.Printf("%v", bumpres)
 }
+
 func Test_BigPayment(t *testing.T) {
+	// NOTE: It seems that this test only performs a payment between two lnd
+	// nodes. Do we really need to test core lnd functionality?
+	// -> This should be removed I guess.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lndConn1, err := getClientConnectenLocal(ctx, 2)
@@ -628,6 +641,11 @@ func Test_BigPayment(t *testing.T) {
 	log.Printf("payreq: %v", sendToRoute)
 }
 
+func Test_PaymentNotifierMaxCalledOnce(t *testing.T) {
+	lnd := lndconn
+}
+
+// NOTE: Please remove this part if not needed anymore!
 // No featurebit pr for now
 // func Test_Featurebits(t *testing.T) {
 // 	ctx, cancel := context.WithCancel(context.Background())

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -271,10 +271,7 @@ func (w *AwaitPaymentOrCsvAction) Execute(services *SwapServices, swap *SwapData
 	}
 
 	// invoice payment part
-	alreadyPaid := services.lightning.AddPaymentNotifier(swap.GetId().String(), swap.OpeningTxBroadcasted.Payreq, INVOICE_CLAIM)
-	if alreadyPaid {
-		return Event_OnClaimInvoicePaid
-	}
+	services.lightning.AddPaymentNotifier(swap.GetId().String(), swap.OpeningTxBroadcasted.Payreq, INVOICE_CLAIM)
 
 	// csv part
 	wantScript, err := wallet.GetOutputScript(swap.GetOpeningParams())
@@ -291,10 +288,7 @@ type AwaitFeeInvoicePayment struct{}
 
 func (w *AwaitFeeInvoicePayment) Execute(services *SwapServices, swap *SwapData) EventType {
 	// invoice payment part
-	alreadyPaid := services.lightning.AddPaymentNotifier(swap.GetId().String(), swap.SwapOutAgreement.Payreq, INVOICE_FEE)
-	if alreadyPaid {
-		return Event_OnFeeInvoicePaid
-	}
+	services.lightning.AddPaymentNotifier(swap.GetId().String(), swap.SwapOutAgreement.Payreq, INVOICE_FEE)
 	return NoOp
 }
 

--- a/swap/services.go
+++ b/swap/services.go
@@ -39,7 +39,7 @@ type LightningClient interface {
 	PayInvoice(payreq string) (preImage string, err error)
 	GetPayreq(msatAmount uint64, preimage string, swapId string, invoiceType InvoiceType, expirySeconds uint64) (string, error)
 	AddPaymentCallback(f func(swapId string, invoiceType InvoiceType))
-	AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType) (alreadyPaid bool)
+	AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType)
 	RebalancePayment(payreq string, channel string) (preimage string, err error)
 }
 

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -253,8 +253,7 @@ type dummyLightningClient struct {
 	failpayment     bool
 }
 
-func (d *dummyLightningClient) AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType) (alreadyPaid bool) {
-	return false
+func (d *dummyLightningClient) AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType) {
 }
 
 func (d *dummyLightningClient) RebalancePayment(payreq string, channel string) (preimage string, err error) {


### PR DESCRIPTION
PR #65 removes multiple subscriptions to lnd `SubscribeSingleInvoice` but still calls the method in a for loop without need. Same for the cln `waitinvoice` call.

This PR refactors these methods to take the invocations out of the loops.