### PR TITLE
CLN: INFO print version during startup instead of DEBUG

### DIFF
--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -88,7 +88,7 @@ func run() error {
 	}()
 	<-initChan
 	log.SetLogger(clightning.NewGlightninglogger(lightningPlugin.Plugin))
-	log.Debugf("PeerSwap Initialized, running PeerSwap commit %s", GitCommit)
+	log.Infof("PeerSwap Initialized, running PeerSwap commit %s", GitCommit)
 	config, err := lightningPlugin.GetConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
This should be in everyone's log so it's easier to know what version they are running for bug reports.