### PR TITLE
Add tests for large swaps

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -75,6 +75,7 @@ start_nodes_lnd() {
     --logdir=/tmp/lnd-regtest-$i/logs \
     --externalip=127.0.0.1:$listenport \
     --listen=0.0.0.0:$listenport \
+    --protocol.wumbo-channels \
     --configfile=/tmp/lnd-regtest-$1/lnd.conf > /dev/null 2>&1 &
     # shellcheck disable=SC2139 disable=SC2086
     alias lncli-$i="$LNCLI --lnddir=/tmp/lnd-regtest-$i --network regtest --rpcserver=localhost:$rpcport"
@@ -143,6 +144,7 @@ bitcoin-rpcuser=admin1
 bitcoin-rpcpassword=123
 bitcoin-rpcconnect=127.0.0.1
 bitcoin-rpcport=18443
+large-channels
 EOF
     # If we've configured to use developer, add dev options
     if $LIGHTNINGD --help | grep -q dev-fast-gossip; then

--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -19,7 +19,7 @@ func Test_ClnCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -85,7 +85,7 @@ func Test_ClnCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -151,7 +151,7 @@ func Test_ClnCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -223,7 +223,7 @@ func Test_ClnCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -289,7 +289,7 @@ func Test_ClnCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -355,7 +355,7 @@ func Test_ClnCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -427,7 +427,7 @@ func Test_ClnLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -496,7 +496,7 @@ func Test_ClnLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -565,7 +565,7 @@ func Test_ClnLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -641,7 +641,7 @@ func Test_ClnLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -710,7 +710,7 @@ func Test_ClnLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -779,7 +779,7 @@ func Test_ClnLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")

--- a/test/bitcoin_lnd_test.go
+++ b/test/bitcoin_lnd_test.go
@@ -20,7 +20,7 @@ func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -99,7 +99,7 @@ func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -178,7 +178,7 @@ func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -264,7 +264,7 @@ func Test_LndLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -345,7 +345,7 @@ func Test_LndLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -426,7 +426,7 @@ func Test_LndLnd_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(6)))
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -512,7 +512,7 @@ func Test_LndCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -590,7 +590,7 @@ func Test_LndCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -669,7 +669,7 @@ func Test_LndCln_Bitcoin_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -753,7 +753,7 @@ func Test_LndCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -831,7 +831,7 @@ func Test_LndCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -909,7 +909,7 @@ func Test_LndCln_Bitcoin_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, lightningds, peerswapd, scid := mixedSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")

--- a/test/liquid_cln_test.go
+++ b/test/liquid_cln_test.go
@@ -19,7 +19,7 @@ func Test_ClnCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -89,7 +89,7 @@ func Test_ClnCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -159,7 +159,7 @@ func Test_ClnCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -235,7 +235,7 @@ func Test_ClnCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -305,7 +305,7 @@ func Test_ClnCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -375,7 +375,7 @@ func Test_ClnCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -451,7 +451,7 @@ func Test_ClnLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -525,7 +525,7 @@ func Test_ClnLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -599,7 +599,7 @@ func Test_ClnLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -680,7 +680,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -694,12 +694,12 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 						lines: defaultLines,
 					},
 					tailableProcess{
-						p:      lightningds[0].(*testframework.CLightningNode).DaemonProcess,
+						p:      lightningds[0].(*CLightningNodeWithLiquid).DaemonProcess,
 						filter: filter,
 						lines:  defaultLines,
 					},
 					tailableProcess{
-						p:     lightningds[1].(*testframework.LndNode).DaemonProcess,
+						p:     lightningds[1].(*LndNodeWithLiquid).DaemonProcess,
 						lines: defaultLines,
 					},
 					tailableProcess{
@@ -753,7 +753,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -826,7 +826,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")

--- a/test/liquid_lnd_test.go
+++ b/test/liquid_lnd_test.go
@@ -19,7 +19,7 @@ func Test_LndLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -103,7 +103,7 @@ func Test_LndLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -187,7 +187,7 @@ func Test_LndLnd_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -277,7 +277,7 @@ func Test_LndLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -362,7 +362,7 @@ func Test_LndLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -447,7 +447,7 @@ func Test_LndLnd_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(6)))
+		bitcoind, liquidd, lightningds, peerswapds, scid := lndlndElementsSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
 				pprintFail(
@@ -538,7 +538,7 @@ func Test_LndCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -620,7 +620,7 @@ func Test_LndCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -702,7 +702,7 @@ func Test_LndCln_Liquid_SwapIn(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_CLN)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_CLN)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -790,7 +790,7 @@ func Test_LndCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -872,7 +872,7 @@ func Test_LndCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")
@@ -954,7 +954,7 @@ func Test_LndCln_Liquid_SwapOut(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(6)), FUNDER_LND)
+		bitcoind, liquidd, lightningds, peerswapd, scid := mixedElementsSetup(t, uint64(math.Pow10(9)), FUNDER_LND)
 		defer func() {
 			if t.Failed() {
 				filter := os.Getenv("PEERSWAP_TEST_FILTER")

--- a/test/testcases.go
+++ b/test/testcases.go
@@ -43,8 +43,11 @@ func coopClaimTest(t *testing.T, params *testParams) {
 	// Move local balance from taker to maker so that the taker does not
 	// have enough balance to pay the invoice and cancels the swap coop.
 	moveAmt := (params.origTakerBalance - params.swapAmt) + 100
-	batches := 2
-	shiftBalance(t, params.takerNode, params.makerNode, params.scid, moveAmt, batches, testframework.TIMEOUT)
+	inv, err := params.makerNode.AddInvoice(moveAmt, "shift balance", "")
+	require.NoError(err)
+
+	err = params.takerNode.SendPay(inv, params.scid)
+	require.NoError(err)
 
 	// Check channel taker balance is less than the swapAmt.
 	var setTakerFunds uint64

--- a/test/utils.go
+++ b/test/utils.go
@@ -150,22 +150,6 @@ func waitForBlockheightSync(t *testing.T, timeout time.Duration, nodes ...testfr
 	}
 }
 
-func shiftBalance(t *testing.T, from testframework.LightningNode, to testframework.LightningNode,
-	scid string, amt uint64, batches int, timeout time.Duration) error {
-
-	// We have to do this in batches as it would fail on big amounts.
-	var inv string
-	var err error
-	for i := 0; i < batches; i++ {
-		inv, err = to.AddInvoice(amt/uint64(batches), "shift balance", "")
-		require.NoError(t, err)
-
-		err = from.PayInvoice(inv)
-		require.NoError(t, err)
-	}
-	return nil
-}
-
 func waitForTxInMempool(t *testing.T, chainRpc *testframework.RpcProxy, timeout time.Duration) (satFee uint64, err error) {
 	err = testframework.WaitFor(func() bool {
 		var mempool map[string]struct {

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -269,9 +269,19 @@ func (n *CLightningNode) FundWallet(sats uint64, mineBlock bool) (string, error)
 		return "", fmt.Errorf("sendtoaddress %w", err)
 	}
 
-	txId, err := r.GetString()
+	var a struct {
+		TxId   string
+		Abc    error
+		Reason int
+	}
+
+	var txId string
+	err = r.GetObject(&a)
 	if err != nil {
-		return "", err
+		txId, err = r.GetString()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	if mineBlock {
@@ -289,7 +299,7 @@ func (n *CLightningNode) FundWallet(sats uint64, mineBlock bool) (string, error)
 }
 
 func (n *CLightningNode) OpenChannel(remote LightningNode, capacity uint64, connect, confirm, waitForActiveChannel bool) (string, error) {
-	_, err := n.FundWallet(10*capacity, true)
+	_, err := n.FundWallet(uint64(1.5*float64(capacity)), true)
 	if err != nil {
 		return "", fmt.Errorf("FundWallet() %w", err)
 	}

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -453,6 +453,32 @@ func (n *CLightningNode) PayInvoice(payreq string) error {
 	return err
 }
 
+func (n *CLightningNode) SendPay(bolt11, scid string) error {
+	decodedBolt11, err := n.Rpc.DecodeBolt11(bolt11)
+	if err != nil {
+		return err
+	}
+
+	_, err = n.Rpc.SendPay([]glightning.RouteHop{
+		{
+			Id:             decodedBolt11.Payee,
+			ShortChannelId: scid,
+			MilliSatoshi:   decodedBolt11.MilliSatoshis,
+			AmountMsat:     decodedBolt11.AmountMsat,
+			Delay:          uint(decodedBolt11.MinFinalCltvExpiry + 1),
+			Direction:      0,
+		},
+	},
+		decodedBolt11.PaymentHash,
+		"",
+		&decodedBolt11.MilliSatoshis,
+		bolt11,
+		decodedBolt11.PaymentSecret,
+		0,
+	)
+	return err
+}
+
 func (n *CLightningNode) GetDataDir() string {
 	return n.dataDir
 }

--- a/testframework/lightning.go
+++ b/testframework/lightning.go
@@ -24,4 +24,5 @@ type LightningNode interface {
 
 	AddInvoice(amtSat uint64, desc, label string) (payreq string, err error)
 	PayInvoice(payreq string) error
+	SendPay(bolt11, scid string) error
 }

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -479,6 +479,10 @@ func (n *LndNode) PayInvoice(payreq string) error {
 	return nil
 }
 
+func (n *LndNode) SendPay(bolt11, _ string) error {
+	return n.PayInvoice(bolt11)
+}
+
 func ScidFromLndChanId(id uint64) string {
 	lndScid := lnwire.NewShortChanIDFromInt(id)
 	return fmt.Sprintf("%dx%dx%d", lndScid.BlockHeight, lndScid.TxIndex, lndScid.TxPosition)


### PR DESCRIPTION
This PR changes all integration tests to test for swaps with size 10btc. Swaps of this size need large (wumbo) channels.