### PR TITLE
Rename GetSatPerKW function. Fix LND fee unit conversion

### DIFF
--- a/clightning/clightning_wallet.go
+++ b/clightning/clightning_wallet.go
@@ -220,7 +220,7 @@ func (cl *ClightningClient) GetFlatSwapOutFee() (uint64, error) {
 	return cl.bitcoinChain.GetFee(218)
 }
 
-func (cl *ClightningClient) GetFeePerKw(targetblocks uint32) (float64, error) {
+func (cl *ClightningClient) GetSatsPerVByte(targetblocks uint32) (float64, error) {
 	if cl.bitcoinNetwork == &chaincfg.RegressionNetParams {
 		return 1, nil
 	}

--- a/lnd/lnd_wallet.go
+++ b/lnd/lnd_wallet.go
@@ -256,11 +256,11 @@ func NewLndFeeEstimator(ctx context.Context, walletkit walletrpc.WalletKitClient
 	return &LndFeeEstimator{ctx: ctx, walletkit: walletkit}
 }
 
-func (l *LndFeeEstimator) GetFeePerKw(targetBlocks uint32) (float64, error) {
+func (l *LndFeeEstimator) GetSatsPerVByte(targetBlocks uint32) (float64, error) {
 	res, err := l.walletkit.EstimateFee(l.ctx, &walletrpc.EstimateFeeRequest{ConfTarget: int32(targetBlocks)})
 	if err != nil {
 		return 0, err
 	}
 
-	return float64(res.SatPerKw / 4000), nil
+	return float64(res.SatPerKw / 250), nil
 }

--- a/onchain/bitcoin.go
+++ b/onchain/bitcoin.go
@@ -25,7 +25,7 @@ type BitcoinOnChain struct {
 }
 
 type FeeEstimator interface {
-	GetFeePerKw(targetBlocks uint32) (float64, error)
+	GetSatsPerVByte(targetBlocks uint32) (float64, error)
 }
 
 func NewBitcoinOnChain(estimator FeeEstimator, chain *chaincfg.Params) *BitcoinOnChain {
@@ -255,7 +255,7 @@ func (b *BitcoinOnChain) GetFeeSatsFromTx(psbtString, txHex string) (uint64, err
 }
 
 func (b *BitcoinOnChain) GetFee(txSize int) (uint64, error) {
-	satPerByte, err := b.estimator.GetFeePerKw(BitcoinFeeTargetBlocks)
+	satPerByte, err := b.estimator.GetSatsPerVByte(BitcoinFeeTargetBlocks)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- Renamed the GetFeePerKw function to GetSatsPerVByte so that the function name corresponds to the units returned.

- Fixed the conversion from sats/kw to sats/vByte for LND's fee estimator. The scaling factor of 4 was applied inverted (1/4) 

The tests were run successfully, however, there does not appear to be test coverage of this area.