### PR TITLE
Use fix payment route for fee invoice

### DIFF
--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -198,6 +198,49 @@ func (l *Lnd) AddPaymentCallback(f func(swapId string, invoiceType swap.InvoiceT
 	l.paymentCallbacks = append(l.paymentCallbacks, f)
 }
 
+func (l *Lnd) PayInvoiceViaChannel(payreq, scid string) (preimage string, err error) {
+	decoded, err := l.lndClient.DecodePayReq(l.ctx, &lnrpc.PayReqString{PayReq: payreq})
+	if err != nil {
+		return "", err
+	}
+
+	channel, err := l.CheckChannel(scid, uint64(decoded.NumSatoshis))
+	if err != nil {
+		return "", err
+	}
+
+	paymentStream, err := l.routerClient.SendPaymentV2(l.ctx, &routerrpc.SendPaymentRequest{
+		PaymentRequest:  payreq,
+		TimeoutSeconds:  30,
+		OutgoingChanIds: []uint64{channel.ChanId},
+		MaxParts:        1,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		res, err := paymentStream.Recv()
+		if err != nil {
+			return "", err
+		}
+		switch res.Status {
+		case lnrpc.Payment_UNKNOWN:
+			log.Debugf("PayInvoiceViaChannel: payment is unknown")
+		case lnrpc.Payment_SUCCEEDED:
+			return res.PaymentPreimage, nil
+		case lnrpc.Payment_IN_FLIGHT:
+			log.Debugf("PayInvoiceViaChannel: payment still in flight")
+		case lnrpc.Payment_FAILED:
+			return "", fmt.Errorf("payment failure %s", res.FailureReason)
+		default:
+			log.Debugf("PayInvoiceViaChannel: got unexpected payment status %d", res.Status)
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+}
+
 func (l *Lnd) RebalancePayment(payreq string, channelId string) (preimage string, err error) {
 	decoded, err := l.lndClient.DecodePayReq(l.ctx, &lnrpc.PayReqString{PayReq: payreq})
 	if err != nil {
@@ -215,6 +258,7 @@ func (l *Lnd) RebalancePayment(payreq string, channelId string) (preimage string
 		OutgoingChanIds: []uint64{channel.ChanId},
 		MaxParts:        30,
 	})
+
 	for {
 		select {
 		case <-l.ctx.Done():

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -259,6 +259,10 @@ func (l *Lnd) RebalancePayment(payreq string, channelId string) (preimage string
 		MaxParts:        30,
 	})
 
+	if err != nil {
+		return "", err
+	}
+
 	for {
 		select {
 		case <-l.ctx.Done():

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -614,8 +614,8 @@ func (t *AwaitTxConfirmationAction) Execute(services *SwapServices, swap *SwapDa
 	if err != nil {
 		return swap.HandleError(err)
 	}
-
 	txWatcher.AddWaitForConfirmationTx(swap.GetId().String(), swap.OpeningTxBroadcasted.TxId, swap.OpeningTxBroadcasted.ScriptOut, swap.StartingBlockHeight, wantScript)
+	log.Debugf("Await confirmation for tx with id: %s on swap %s", swap.OpeningTxBroadcasted.TxId, swap.GetId().String())
 	return NoOp
 }
 

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -566,7 +566,7 @@ func (r *PayFeeInvoiceAction) Execute(services *SwapServices, swap *SwapData) Ev
 		return swap.HandleError(errors.New(fmt.Sprintf("Fee is too damn high. Max expected: %v Received %v", maxExpected, swap.OpeningTxFee)))
 	}
 
-	preimage, err := ll.PayInvoice(swap.SwapOutAgreement.Payreq)
+	preimage, err := ll.PayInvoiceViaChannel(swap.SwapOutAgreement.Payreq, swap.GetScid())
 	if err != nil {
 		return swap.HandleError(err)
 	}

--- a/swap/services.go
+++ b/swap/services.go
@@ -38,6 +38,7 @@ type LightningClient interface {
 	DecodePayreq(payreq string) (paymentHash string, amountMsat uint64, err error)
 	PayInvoice(payreq string) (preImage string, err error)
 	GetPayreq(msatAmount uint64, preimage string, swapId string, memo string, invoiceType InvoiceType, expirySeconds uint64) (string, error)
+	PayInvoiceViaChannel(payreq string, channel string) (preimage string, err error)
 	AddPaymentCallback(f func(swapId string, invoiceType InvoiceType))
 	AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType)
 	RebalancePayment(payreq string, channel string) (preimage string, err error)

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -316,6 +316,20 @@ func (d *dummyLightningClient) PayInvoice(payreq string) (preImage string, err e
 	return pi.String(), nil
 }
 
+func (d *dummyLightningClient) PayInvoiceViaChannel(payreq, scid string) (preimage string, err error) {
+	if d.failpayment {
+		return "", errors.New("payment failed")
+	}
+	if payreq == "err" {
+		return "", errors.New("error paying invoice")
+	}
+	pi, err := lightning.GetPreimage()
+	if err != nil {
+		return "", err
+	}
+	return pi.String(), nil
+}
+
 type dummyPolicy struct {
 }
 

--- a/test/testcases.go
+++ b/test/testcases.go
@@ -137,6 +137,7 @@ func preimageClaimTest(t *testing.T, params *testParams) {
 	require.NoError(err)
 
 	// Confirm opening tx.
+	require.NoError(params.takerPeerswap.WaitForLog("Await confirmation for tx", testframework.TIMEOUT))
 	params.chaind.GenerateBlocks(params.confirms)
 	waitForBlockheightSync(t, testframework.TIMEOUT, params.takerNode, params.makerNode)
 


### PR DESCRIPTION
This pr adds an explicit route (the direct channel to the peer that is swapped on) to the fee payment. Resolves #61 