### PR TITLE
Fix aarch64 build: dup2 is unsupported, use dup3

### DIFF
--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -624,7 +624,7 @@ func setPanicLogger() (func() error, error) {
 		return nil, err
 	}
 
-	err = syscall.Dup2(int(panicLogFile.Fd()), int(os.Stderr.Fd()))
+	err = syscall.Dup3(int(panicLogFile.Fd()), int(os.Stderr.Fd()), 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
$ make cln-release
go build -o peerswap-plugin -ldflags "-X main.GitCommit=1503d310bba9727a6b149ae53527287688803f92" ./cmd/peerswap-plugin/main.go
go: downloading golang.org/x/sys v0.0.0-20210915083310-ed5796bab164
# command-line-arguments
cmd/peerswap-plugin/main.go:627:8: undefined: syscall.Dup2
make: *** [Makefile:62: cln-release] Error 2
```

dup2 is unsupported on aarch64. Switch to dup3.

**How to Test**

- Find the process ID number of peerswap-plugin.
- `kill -SIGABRT <PROCESSID>`
- Look in your peerswap datadir (default `~/.lightning/bitcoin/peerswap`) for `peerswap-panic-log`.

If successful you should see something like this:
```
SIGABRT: abort
PC=0x471801 m=0 sigcode=0
```

To be safe let's confirm this works on all currently working platforms and archs.

- x86_64 Everyone
- ppc64le @grubles 
- aarch64 @openoms @AaronDewes 


