### PR TITLE
Add grpc retry to requests and streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        test-vector: [bitcoin-cln, bitcoin-lnd, liquid-cln, liquid-lnd]
+        test-vector: [
+          bitcoin-cln,
+          bitcoin-lnd,
+          liquid-cln,
+          liquid-lnd,
+          misc-integration
+          ]
     steps:
       - uses: actions/checkout@v2
       

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ test-liquid-lnd: build-with-fast-test
 	RUN_INTEGRATION_TESTS=1 PAYMENT_RETRY_TIME=$(PAYMENT_RETRY_TIME) PEERSWAP_TEST_FILTER=$(PEERSWAP_TEST_FILTER) go test -tags dev -tags fast_test -timeout=30m -v -run '^(Test_LndLnd_Liquid_SwapOut|Test_LndLnd_Liquid_SwapIn|Test_LndCln_Liquid_SwapOut|Test_LndCln_Liquid_SwapIn)$'' github.com/elementsproject/peerswap/test
 .PHONY: test-liquid-lnd
 
+test-misc-integration: build-with-fast-test
+	RUN_INTEGRATION_TESTS=1 PAYMENT_RETRY_TIME=$(PAYMENT_RETRY_TIME) PEERSWAP_TEST_FILTER=$(PEERSWAP_TEST_FILTER) go test -tags dev -tags fast_test -timeout=30m -v -run '^(Test_GrpcReconnectStream|Test_GrpcRetryRequest)$'' github.com/elementsproject/peerswap/test
+.PHONY: test-misc-integration
+
 lnd-release:
 	go build -o peerswapd -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswaplnd/peerswapd/main.go
 	go build -o pscli -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswaplnd/pscli/main.go

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890
 	github.com/elementsproject/glightning v0.0.0-20220713160855-49a9a8ec3e4d
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
@@ -22,3 +23,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/macaroon.v2 v2.1.0
 )
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/nepet/go-grpc-middleware v1.3.1-0.20220724185904-d87620a32fc7
+
+// replace github.com/grpc-ecosystem/go-grpc-middleware => ../go-grpc-middleware

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,9 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -282,9 +283,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
-github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -493,8 +491,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nepet/glightning v0.0.0-20220712170505-692129949f10 h1:pl999PCb3pvtdhfHWznQviW6+MOdRH4vy8OWVD4aif4=
-github.com/nepet/glightning v0.0.0-20220712170505-692129949f10/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
+github.com/nepet/go-grpc-middleware v1.3.1-0.20220724185904-d87620a32fc7 h1:TpHCbKJiYHf48zCab0/nwxBH2iSBfrET5lQZx+dDtS0=
+github.com/nepet/go-grpc-middleware v1.3.1-0.20220724185904-d87620a32fc7/go.mod h1:RCPk9z9htrr5+ycrsjLDqcNS5qHpBOOTeZGJvF5c9As=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nwaples/rardecode v1.1.2 h1:Cj0yZY6T1Zx1R7AhTbyGSALm44/Mmq+BAPc4B/p/d3M=
 github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
@@ -686,8 +684,9 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
-go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.18.1 h1:CSUJ2mjFszzEWt4CdKISEuChVIXGBn3lAPwkRGyVrc4=
+go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/lnd/connection.go
+++ b/lnd/connection.go
@@ -1,0 +1,38 @@
+package lnd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/elementsproject/peerswap/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// WaitForReady checks on the status of a grpc client connection. We wait until
+// the connection is READY or until timeout. Is a blocking call. Returns an
+// error on timeout.
+func WaitForReady(conn *grpc.ClientConn, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	state := conn.GetState()
+	if state == connectivity.Ready {
+		return nil
+	}
+
+	log.Debugf("Waiting for client connection to be READY: current state: %s", state)
+
+	for {
+		ok := conn.WaitForStateChange(ctx, state)
+		if !ok {
+			return fmt.Errorf("waiting for client connection to be READY: timeout")
+		}
+		state = conn.GetState()
+		log.Debugf("Waiting for client connection to be READY: state changed: %s", state)
+		if state == connectivity.Ready {
+			return nil
+		}
+	}
+}

--- a/lnd/connection_test.go
+++ b/lnd/connection_test.go
@@ -1,0 +1,284 @@
+package lnd
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+func TestWaitForReady_OnStop(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+
+	s, _ := newTestServer(t, l)
+	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+
+	// Expecting waitForReady to return without an error as the state should be
+	// READY.
+	err = WaitForReady(cc, 10*time.Second)
+	if err != nil {
+		t.Fatalf("waitForReady failed: %v", err)
+	}
+
+	// Stop the server to drop the connection.
+	s.Stop()
+	// Wait for connection to drop.
+	cc.WaitForStateChange(context.Background(), connectivity.Ready)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var wfErr error
+	// We expect waitForReady to return without an error detecting the fixed
+	// connection once we spin up the server again.
+	go func() {
+		defer wg.Done()
+		wfErr = WaitForReady(cc, 10*time.Second)
+	}()
+
+	// Restart the server on the same network and address.
+	l, err = net.Listen(l.Addr().Network(), l.Addr().String())
+	if err != nil {
+		t.Errorf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+	_, _ = newTestServer(t, l)
+
+	// Wait here until go routine above returns indicating that waitForReady has
+	// returned due to the state being READY again or timeout. We are expecting
+	// no timeout error.
+	wg.Wait()
+	if wfErr != nil {
+		t.Fatalf("waitForReady failed: %v", wfErr)
+	}
+}
+
+func TestWaitForReady_OnGracefulStop(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+
+	s, _ := newTestServer(t, l)
+	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+
+	// Expecting waitForReady to return without an error as the state should be
+	// READY.
+	err = WaitForReady(cc, 10*time.Second)
+	if err != nil {
+		t.Fatalf("waitForReady failed: %v", err)
+	}
+
+	// Stop the server to drop the connection.
+	s.GracefulStop()
+	// Wait for connection to drop.
+	cc.WaitForStateChange(context.Background(), connectivity.Ready)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var wfErr error
+	// We expect waitForReady to return without an error detecting the fixed
+	// connection once we spin up the server again.
+	go func() {
+		defer wg.Done()
+		wfErr = WaitForReady(cc, 10*time.Second)
+	}()
+
+	// Restart the server on the same network and address.
+	l, err = net.Listen(l.Addr().Network(), l.Addr().String())
+	if err != nil {
+		t.Errorf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+	_, _ = newTestServer(t, l)
+
+	// Wait here until go routine above returns indicating that waitForReady has
+	// returned due to the state being READY again or timeout. We are expecting
+	// no timeout error.
+	wg.Wait()
+	if wfErr != nil {
+		t.Fatalf("waitForReady failed: %v", wfErr)
+	}
+}
+
+func TestResubscribeToStream(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+
+	s, ts := newTestServer(t, l)
+	defer s.Stop()
+
+	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	client := testgrpc.NewTestServiceClient(cc)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	resCh := make(chan bool)
+	errs := make(chan error, 1)
+	// This is an example implementation of a service that is subscribed to a
+	// stream.
+	go func() {
+		defer wg.Done()
+
+		// Subscribe to stream.
+		stream, err := client.StreamingOutputCall(
+			context.Background(),
+			&testpb.StreamingOutputCallRequest{},
+		)
+		if err != nil {
+			t.Logf("StreamingOutputCall() failed: %v", err)
+			errs <- err
+			return
+		}
+
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				// If we receive an io.EOF error this means that the stream has
+				// been closed by the server.
+				t.Log("Server closed connection")
+				return
+			}
+			if err != nil {
+				// If we received a different error than an io.EOF error this is
+				// an indication that the server has crashed or been stopped. If
+				// this is the case we want to wait until we can reconnect.
+				// After we are reconnected to the server, we open a new stream.
+				t.Logf("Got an error: %v\n", err)
+				errs <- err
+
+				WaitForReady(cc, 20*time.Second)
+
+				// Subscibe to new stream.
+				stream, err = client.StreamingOutputCall(
+					context.Background(),
+					&testpb.StreamingOutputCallRequest{},
+				)
+				if err != nil {
+					t.Logf("StreamingOutputCall() failed: %v", err)
+					errs <- err
+				}
+				continue
+			}
+			// We got a response from the server: handle response.
+			resCh <- true
+
+		}
+	}()
+
+	// Check if stream is receiving the response.
+	ts.sendStreamingOutput()
+	<-resCh
+
+	// Stop server to break the grpc connection. Expecting a connection error
+	// from the server.
+	s.Stop()
+	<-errs
+
+	// Restart server.
+	l, err = net.Listen(l.Addr().Network(), l.Addr().String())
+	if err != nil {
+		t.Errorf("net.Listen() failed: %v", err)
+	}
+	defer l.Close()
+	_, ts = newTestServer(t, l)
+
+	// The example service should reconnect and resubscribe to the stream. We
+	// are expecting that the service is receiving a response.
+	ts.sendStreamingOutput()
+	<-resCh
+
+	// Stop the stream and wait for example service go routine to finish.
+	ts.stopStreamingOutput()
+	wg.Wait()
+}
+
+// testServer is a minimalistic grpc server mock that allows us to send to a
+// stream as well as closing a stream on demand.
+type testServer struct {
+	t *testing.T
+	testpb.UnimplementedTestServiceServer
+
+	sendOutputCh chan bool
+	stop         chan bool
+}
+
+func newTestServer(t *testing.T, l net.Listener) (*grpc.Server, *testServer) {
+	s := grpc.NewServer()
+	ts := &testServer{
+		t:            t,
+		sendOutputCh: make(chan bool),
+		stop:         make(chan bool),
+	}
+	testgrpc.RegisterTestServiceServer(s, ts)
+	go func() {
+		err := s.Serve(l)
+		if err != nil {
+			t.Logf("s.Serve() failed: %v", err)
+		}
+	}()
+	return s, ts
+}
+
+func (t testServer) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+	t.t.Log("EmptyCall was called")
+	return &testpb.Empty{}, nil
+}
+
+// StreamingOutputCall sends a message to the stream when triggered by the
+// sendOutputCh channel.
+func (t testServer) StreamingOutputCall(req *testpb.StreamingOutputCallRequest, srv testpb.TestService_StreamingOutputCallServer) error {
+	for {
+		select {
+		case <-t.sendOutputCh:
+			go func() {
+				if err := srv.Send(
+					&testpb.StreamingOutputCallResponse{
+						Payload: &testpb.Payload{
+							Type: testpb.PayloadType_RANDOM,
+							Body: []byte("whatever"),
+						},
+					},
+				); err != nil {
+					t.t.Fatalf("Send() failed: %v", err)
+				}
+			}()
+		case <-t.stop:
+			return nil
+		}
+	}
+}
+
+// sendStreamingOutput triggers the server to send a message to the stream.
+func (t *testServer) sendStreamingOutput() {
+	t.sendOutputCh <- true
+}
+
+// stopStreamingOutput stops a stream gracefully.
+func (t *testServer) stopStreamingOutput() {
+	t.stop <- true
+}

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elementsproject/peerswap/cmd/peerswaplnd"
 	"github.com/elementsproject/peerswap/log"
 
 	"github.com/elementsproject/peerswap/lightning"
@@ -17,6 +18,7 @@ import (
 	"github.com/elementsproject/peerswap/onchain"
 	"github.com/elementsproject/peerswap/poll"
 	"github.com/elementsproject/peerswap/swap"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
@@ -24,8 +26,54 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"gopkg.in/macaroon.v2"
+)
+
+const (
+	// defaultGrpcBackoffTime is the linear backoff time between failing grpc
+	// calls (also server side stream) to the lnd node.
+	defaultGrpcBackoffTime   = 1 * time.Second
+	defaultGrpcBackoffJitter = 0.1
+
+	// defaultMaxGrpcRetries is the amount of retries we take if the grpc
+	// connection to the lnd node drops for some reason or if the resource is
+	// exhausted. With the defaultGrpcBackoffTime and a linear backoff stratefgy
+	// this leads to roughly 5h of retry time.
+	defaultMaxGrpcRetries = 5
+)
+
+var (
+	// defaultGrpcRetryCodes are the grpc status codes that are returned with an
+	// error, on which we retry our call (and server side stream) to the lnd
+	// node. The codes represent:
+	// - Unavailable:	The service is currently unavailable. This is most
+	//					likely a transient condition, which can be corrected by
+	//					retrying with a backoff. Note that it is not always safe
+	//					to retry non-idempotent operations.
+	//
+	// - ResourceExhausted:	Some resource has been exhausted, perhaps a per-user
+	//						quota, or perhaps the entire file system is out of
+	//						space.
+	defaultGrpcRetryCodes []codes.Code = []codes.Code{
+		codes.Unavailable,
+		codes.ResourceExhausted,
+	}
+
+	// defaultGrpcRetryCodesWithMsg are grpc status codes that must have a
+	// matching message for us to retry. This is due to LND using a confusing
+	// rpc error code on startup.
+	// See: https://github.com/lightningnetwork/lnd/issues/6765
+	//
+	// This is also the reason that we need to use a fork of the
+	// go-grpc-middleware "retry" to provide this optional check.
+	defaultGrpcRetryCodesWithMsg []grpc_retry.CodeWithMsg = []grpc_retry.CodeWithMsg{
+		{
+			Code: codes.Unknown,
+			Msg:  "the RPC server is in the process of starting up, but not yet ready to accept calls",
+		},
+	}
 )
 
 type Lnd struct {
@@ -464,4 +512,53 @@ func getClientConnection(ctx context.Context, tlsCertPath, macaroonPath, address
 
 func LndShortChannelIdToCLShortChannelId(lndCI lnwire.ShortChannelID) string {
 	return fmt.Sprintf("%dx%dx%d", lndCI.BlockHeight, lndCI.TxIndex, lndCI.TxPosition)
+}
+
+func GetLndClientConnection(ctx context.Context, cfg *peerswaplnd.LndConfig) (*grpc.ClientConn, error) {
+	creds, err := credentials.NewClientTLSFromFile(cfg.TlsCertPath, "")
+	if err != nil {
+		return nil, err
+	}
+	macBytes, err := ioutil.ReadFile(cfg.MacaroonPath)
+	if err != nil {
+		return nil, err
+	}
+	mac := &macaroon.Macaroon{}
+	if err := mac.UnmarshalBinary(macBytes); err != nil {
+		return nil, err
+	}
+	cred, err := macaroons.NewMacaroonCredential(mac)
+	if err != nil {
+		return nil, err
+	}
+	maxMsgRecvSize := grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 500)
+
+	retryOptions := []grpc_retry.CallOption{
+		grpc_retry.WithBackoff(
+			grpc_retry.BackoffExponentialWithJitter(
+				defaultGrpcBackoffTime,
+				defaultGrpcBackoffJitter,
+			),
+		),
+		grpc_retry.WithCodes(defaultGrpcRetryCodes...),
+		grpc_retry.WithCodesAndMatchingMessage(defaultGrpcRetryCodesWithMsg...),
+		grpc_retry.WithMax(defaultMaxGrpcRetries),
+	}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithBlock(),
+		grpc.WithPerRPCCredentials(cred),
+		grpc.WithDefaultCallOptions(maxMsgRecvSize),
+		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(
+			retryOptions...,
+		)),
+		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(
+			retryOptions...,
+		)),
+	}
+	conn, err := grpc.DialContext(ctx, cfg.LndHost, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
 }

--- a/test/grpc_retry_test.go
+++ b/test/grpc_retry_test.go
@@ -1,0 +1,241 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elementsproject/peerswap/cmd/peerswaplnd"
+	"github.com/elementsproject/peerswap/lightning"
+	peerswaplndinternal "github.com/elementsproject/peerswap/lnd"
+	"github.com/elementsproject/peerswap/testframework"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func Test_GrpcRetryRequest(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	// Setup bitcoind and lnd.
+	tmpDir := t.TempDir()
+	bitcoind, err := testframework.NewBitcoinNode(tmpDir, 1)
+	if err != nil {
+		t.Fatalf("Can not create bitcoin node: %v", err)
+	}
+
+	lnd, err := testframework.NewLndNode(tmpDir, bitcoind, 1, nil)
+	if err != nil {
+		t.Fatalf("Can not create lnd node: %v", err)
+	}
+
+	if err := bitcoind.Run(true); err != nil {
+		t.Fatalf("Can not start bitcoind: %v", err)
+	}
+	t.Cleanup(bitcoind.Kill)
+
+	if err := lnd.Run(true, true); err != nil {
+		t.Fatalf("Can not start lnd: %v", err)
+	}
+	t.Cleanup(lnd.Kill)
+
+	// Create a client connection to the lnd node. And a new lnd client.
+	cc, err := peerswaplndinternal.GetLndClientConnection(
+		context.Background(),
+		&peerswaplnd.LndConfig{
+			LndHost:      fmt.Sprintf("localhost:%d", lnd.RpcPort),
+			TlsCertPath:  lnd.TlsPath,
+			MacaroonPath: lnd.MacaroonPath,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Could not create lnd client connection: %v", err)
+	}
+	lnrpcClient := lnrpc.NewLightningClient(cc)
+
+	// Assert that getinfo returns no error.
+	_, err = lnrpcClient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetInfo() failed: %v", err)
+	}
+
+	// We now kill the lnd node and fire a request in the go routine. We wait a
+	// random time between 1 and 6 seconds and restart the node. We expect the
+	// call to retry and return with no error.
+	lnd.Kill()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	var fErr error
+	go func() {
+		defer wg.Done()
+		_, fErr = lnrpcClient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
+	}()
+
+	n := rand.Intn(5) + 1
+	time.Sleep(time.Duration(n) * time.Second)
+	lnd.Run(true, true)
+
+	// Wait for GetInfo to return
+	wg.Wait()
+	assert.NoError(t, fErr)
+}
+
+func Test_GrpcReconnectStream(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	// Setup bitcoind and lnd.
+	tmpDir := t.TempDir()
+	bitcoind, err := testframework.NewBitcoinNode(tmpDir, 1)
+	if err != nil {
+		t.Fatalf("Can not create bitcoin node: %v", err)
+	}
+
+	lnd, err := testframework.NewLndNode(tmpDir, bitcoind, 1, nil)
+	if err != nil {
+		t.Fatalf("Can not create lnd node: %v", err)
+	}
+
+	if err := bitcoind.Run(true); err != nil {
+		t.Fatalf("Can not start bitcoind: %v", err)
+	}
+	t.Cleanup(bitcoind.Kill)
+
+	if err := lnd.Run(true, true); err != nil {
+		t.Fatalf("Can not start lnd: %v", err)
+	}
+	t.Cleanup(lnd.Kill)
+
+	// Create a client connection to the lnd node. And a new lnd client.
+	cc, err := peerswaplndinternal.GetLndClientConnection(
+		context.Background(),
+		&peerswaplnd.LndConfig{
+			LndHost:      fmt.Sprintf("localhost:%d", lnd.RpcPort),
+			TlsCertPath:  lnd.TlsPath,
+			MacaroonPath: lnd.MacaroonPath,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Could not create lnd client connection: %v", err)
+	}
+	lnrpcClient := lnrpc.NewLightningClient(cc)
+
+	// Add some invoices to prepopulate the database. We can only subscribe to
+	// invoices with an AddIndex > 1 if we want to return the invoices that we
+	// missed again.
+	for i := 0; i < 10; i++ {
+		preimage, _ := lightning.GetPreimage()
+		_, err = lnrpcClient.AddInvoice(
+			context.Background(),
+			&lnrpc.Invoice{
+				ValueMsat: int64(1000000) + int64(i),
+				Memo:      fmt.Sprintf("memo-%d", i),
+				RPreimage: preimage[:],
+			},
+		)
+		if err != nil {
+			t.Fatalf("AddInvoice() failed: %v", err)
+		}
+	}
+
+	// Subscribe to invoices
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	var fErr error
+	var results []*lnrpc.Invoice
+	go func() {
+		defer wg.Done()
+
+		var stream lnrpc.Lightning_SubscribeInvoicesClient
+		stream, fErr = lnrpcClient.SubscribeInvoices(
+			context.Background(),
+			&lnrpc.InvoiceSubscription{AddIndex: 1},
+			grpc_retry.WithMax(10),
+			grpc_retry.WithCodesAndMatchingMessage(grpc_retry.CodeWithMsg{
+				Code: codes.Unknown,
+				Msg:  "the RPC server is in the process of starting up, but not yet ready to accept calls",
+			}),
+		)
+		if fErr != nil {
+			return
+		}
+
+		var index uint64 = 0
+		for {
+			if len(results) >= 11 {
+				return
+			}
+
+			var r *lnrpc.Invoice
+			r, fErr = stream.Recv()
+			if fErr == io.EOF {
+				return
+			} else if fErr != nil {
+				return
+			}
+			if r.AddIndex > index {
+				results = append(results, r)
+				index = r.AddIndex
+			}
+		}
+	}()
+
+	preimage, _ := lightning.GetPreimage()
+	_, err = lnrpcClient.AddInvoice(
+		context.Background(),
+		&lnrpc.Invoice{
+			ValueMsat: int64(1000000),
+			Memo:      "mymemo",
+			RPreimage: preimage[:],
+		},
+	)
+	if err != nil {
+		t.Fatalf("AddInvoice() failed: %v", err)
+	}
+
+	err = testframework.WaitFor(func() bool {
+		return len(results) > 0
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("WaitFor() failed: %v", err)
+	}
+
+	// We now kill the lnd node and wait a random time between 1s and 6s before
+	// we restart the node. We expect the stream to resubscribe and return with
+	// no error.
+	lnd.Kill()
+
+	n := rand.Intn(5) + 1
+	time.Sleep(time.Duration(n) * time.Second)
+	lnd.Run(true, true)
+
+	preimage, _ = lightning.GetPreimage()
+	_, err = lnrpcClient.AddInvoice(
+		context.Background(),
+		&lnrpc.Invoice{
+			ValueMsat: int64(1000000),
+			Memo:      "lastmemo",
+			RPreimage: preimage[:],
+		},
+		grpc_retry.WithMax(5),
+		grpc_retry.WithCodesAndMatchingMessage(grpc_retry.CodeWithMsg{
+			Code: codes.Unknown,
+			Msg:  "the RPC server is in the process of starting up, but not yet ready to accept calls",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("AddInvoice() failed: %v", err)
+	}
+
+	wg.Wait()
+	assert.NoError(t, fErr)
+}


### PR DESCRIPTION
This PR adds the go-grpc-middleware `retry`. We need to be able to retry a call or to resubscribe to a stream in the case that the lnd node is unreachable for some time.

This alone will not be sufficient to fix all connection problems with lnd, therefore the watchers (peers, chain, invoices) need a complete rework.
I will provide another PR that takes care of the watcher reworks to keep this PR single tasked and reviewable. That PR will be based on the head of this PR.
