### PR TITLE
bsaes build fix and .gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ cluster/volumes/signet/config/regtest/
 
 cluster/volumes/signet/liquid-config/liquidregtest/
 
-liquid-swap-plugin
-
 db
 dist/
 

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/macaroon.v2 v2.1.0
 )
+
+// Temporary: this server is dead, LND 0.15 no longer refers to this old server address
+replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/NebulousLabs/fastrand v0.0.0-20181203155948-6fb6489aac4e/go.mod h1:Bd
 github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82/go.mod h1:GbuBk21JqF+driLX3XtJYNZjGa45YDoa9IqCTzNSfEc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Yawning/aez v0.0.0-20180114000226-4dad034d9db2/go.mod h1:9pIqrY6SXNL8vjRQE5Hd/OL5GyK/9MrGUWs87z/eFfk=
+github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e h1:n88VxLC80RPVHbFG/kq7ItMizCVRPCyLj63UMqxLkOw=
+github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e/go.mod h1:3JAJz+vEO82SkYEkAa2lRPkQC7lslUY24HX3929i2Ec=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=


### PR DESCRIPTION
```
$ make build
go build -tags dev -o ./out/peerswap-plugin ./cmd/peerswap-plugin/main.go
go: github.com/lightningnetwork/lnd@v0.14.1-beta requires
	git.schwanenlied.me/yawning/bsaes.git@v0.0.0-20180720073208-c0276d75487e: invalid version: git ls-remote -q origin in /home/buildtemp/go/pkg/mod/cache/vcs/d3a2bd2286786f21a7fee0eb4d0004b833f3d1c28224188c1e61e96a9026d034: exit status 128:
	fatal: unable to look up git.schwanenlied.me (port 9418) (Name or service not known)
go: github.com/lightningnetwork/lnd@v0.14.1-beta requires
	git.schwanenlied.me/yawning/bsaes.git@v0.0.0-20180720073208-c0276d75487e: invalid version: git ls-remote -q origin in /home/buildtemp/go/pkg/mod/cache/vcs/d3a2bd2286786f21a7fee0eb4d0004b833f3d1c28224188c1e61e96a9026d034: exit status 128:
	fatal: unable to look up git.schwanenlied.me (port 9418) (Name or service not known)
make: *** [Makefile:14: build] Error 1
```

build fix: lnd-0.14 branch refers to dead git server, point at mirror on github until we don't need it anymore

### How to Test

1. Checkout git repo as a fresh non-root user so you don't have golang artifacts from previous builds.
2. `make build` does it succeed?

Fixes #112
