### PR TITLE
Change estimated size for btc opening tx

### DIFF
--- a/clightning/clightning_wallet.go
+++ b/clightning/clightning_wallet.go
@@ -213,10 +213,12 @@ func (cl *ClightningClient) GetOnchainBalance() (uint64, error) {
 	return totalBalance, nil
 }
 
-// GetFlatSwapOutFee returns a fee that is the size of an opening transaction
-// with 2 inputs and 2 outputs (p2wsh, p2wpkg change): 218 bytes
+// GetFlatSwapOutFee returns an estimated size for the opening transaction. This
+// can be used to calculate the amount of the fee invoice and should cover most
+// but not all cases. For an explanation of the estimation see comments of the
+// onchain.EstimatedOpeningTxSize.
 func (cl *ClightningClient) GetFlatSwapOutFee() (uint64, error) {
-	return cl.bitcoinChain.GetFee(218)
+	return cl.bitcoinChain.GetFee(onchain.EstimatedOpeningTxSize)
 }
 
 func (cl *ClightningClient) GetAsset() string {

--- a/lnd/lnd_wallet.go
+++ b/lnd/lnd_wallet.go
@@ -232,10 +232,12 @@ func (l *Client) GetRefundFee() (uint64, error) {
 	return l.bitcoinOnChain.GetFee(250)
 }
 
-// GetFlatSwapOutFee returns a fee that is the size of an opening transaction
-// with 2 inputs and 2 outputs (p2wsh, p2wpkg change): 218 bytes
+// GetFlatSwapOutFee returns an estimated size for the opening transaction. This
+// can be used to calculate the amount of the fee invoice and should cover most
+// but not all cases. For an explanation of the estimation see comments of the
+// onchain.EstimatedOpeningTxSize.
 func (l *Client) GetFlatSwapOutFee() (uint64, error) {
-	return l.bitcoinOnChain.GetFee(218)
+	return l.bitcoinOnChain.GetFee(onchain.EstimatedOpeningTxSize)
 }
 
 func (cl *Client) GetAsset() string {

--- a/onchain/bitcoin.go
+++ b/onchain/bitcoin.go
@@ -34,6 +34,16 @@ const (
 	// it is too close to the csv limit to pay the invoice.
 	BitcoinCsvSafetyLimit = BitcoinCsv / 2
 
+	// EstimatedOpeningTxSize in vByte is the estimated size of a swap opening
+	// transaction with a security margin. The estimate is meant to express the
+	// fees for most, but not all swap out opening tx fees. This is calculated
+	// as follows: The average amount of inputs is 3 with an expected type of
+	// P2WPKH that has a size of 68 vByte. The outputs are a P2WSH and a P2WPKH
+	// output with a total size of 84 vByte including the tx overhead. This
+	// leads to an expected size for the opening tx of (3*68 + 84) = 288 vByte.
+	// We add a security margin to this which leads to the size of 350 vByte.
+	EstimatedOpeningTxSize = 350
+
 	// This defines the absolute floor of the feerate. This will be the minimum
 	// feerate that will be used. The floor is set to 275 sat/kw so that we
 	// always have a minimum fee rate of 1.1 sat/vb.


### PR DESCRIPTION
See #110 
This changes the estimated size of the btc opening tx to `350 vByte`