### PR TITLE
Adjust liquid flat swapout fee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ BUILD_OPTS= \
 
 TEST_BUILD_OPTS= \
 	-ldflags "-X main.GitCommit=$(shell git rev-parse HEAD)" \
-	-tags dev \
-	-tags fast_test
+	-tags "dev fast_test"
 
 INTEGRATION_TEST_ENV= \
 	RUN_INTEGRATION_TESTS=1 \

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -93,7 +93,7 @@ func run() error {
 	log.Infof("PeerSwap CLN starting up with commit %s", GitCommit)
 	log.Infof("DB version: %s, Protocol version: %d", version.GetCurrentVersion(), swap.PEERSWAP_PROTOCOL_VERSION)
 	if isdev.IsDev() {
-		log.Infof("Devmode eneabled.")
+		log.Infof("Dev-mode enabled.")
 	}
 	config, err := lightningPlugin.GetConfig()
 	if err != nil {

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/elementsproject/peerswap/isdev"
 	"github.com/elementsproject/peerswap/log"
 	"github.com/elementsproject/peerswap/version"
 
@@ -91,6 +92,9 @@ func run() error {
 	log.SetLogger(clightning.NewGlightninglogger(lightningPlugin.Plugin))
 	log.Infof("PeerSwap CLN starting up with commit %s", GitCommit)
 	log.Infof("DB version: %s, Protocol version: %d", version.GetCurrentVersion(), swap.PEERSWAP_PROTOCOL_VERSION)
+	if isdev.IsDev() {
+		log.Infof("Devmode eneabled.")
+	}
 	config, err := lightningPlugin.GetConfig()
 	if err != nil {
 		return err

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/elementsproject/peerswap/isdev"
 	"github.com/elementsproject/peerswap/lnd"
 	"github.com/elementsproject/peerswap/log"
 	"github.com/elementsproject/peerswap/version"
@@ -103,6 +104,9 @@ func run() error {
 	}
 	log.Infof("PeerSwap LND starting up with commit %s and cfg: %s", GitCommit, cfg)
 	log.Infof("DB version: %s, Protocol version: %d", version.GetCurrentVersion(), swap.PEERSWAP_PROTOCOL_VERSION)
+	if isdev.IsDev() {
+		log.Infof("Devmode eneabled.")
+	}
 
 	// setup lnd connection
 	cc, err := lnd.GetClientConnection(ctx, cfg.LndConfig)

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -105,7 +105,7 @@ func run() error {
 	log.Infof("PeerSwap LND starting up with commit %s and cfg: %s", GitCommit, cfg)
 	log.Infof("DB version: %s, Protocol version: %d", version.GetCurrentVersion(), swap.PEERSWAP_PROTOCOL_VERSION)
 	if isdev.IsDev() {
-		log.Infof("Devmode eneabled.")
+		log.Infof("Dev-mode enabled.")
 	}
 
 	// setup lnd connection

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -677,6 +677,12 @@ remove_peerswapd() {
   fi
 }
 
+# Setup alias rules for common services
+setup_aliases() {
+  alias lbt-cli='elements-cli -rpcuser=admin1 -rpcpassword=123 -rpcconnect=127.0.0.1 -rpcport=18884'
+  alias bt-cli='bitcoin-cli -regtest -rpcuser=admin1 -rpcpassword=123 -rpcconnect=127.0.0.1 -rpcport=18443'
+}
+
 fund_nodes_l() {
   echo $(lightning-cli-1 dev-liquid-faucet)
   echo $(lightning-cli-1 dev-liquid-faucet)
@@ -688,7 +694,7 @@ l_generate() {
   else
     block_count=$1
   fi
-  res=$(et-cli generatetoaddress $block_count ert1qfkht0df45q00kzyayagw6vqhfhe8ve7z7wecm0xsrkgmyulewlzqumq3ep)
+  res=$(lbt-cli generatetoaddress $block_count ert1qfkht0df45q00kzyayagw6vqhfhe8ve7z7wecm0xsrkgmyulewlzqumq3ep)
   echo $res
 }
 

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -571,10 +571,11 @@ func (l *LiquidOnChain) GetRefundFee() (uint64, error) {
 	return l.getFee(l.getClaimTxSize())
 }
 
-// GetFlatSwapOutFee returns a fee that is the size of an opening transaction
-// with 2 inputs and 3 ouputs (blinded p2wpkh, blinded p2wsh, feeoutput): 2587 bytes
+// GetFlatSwapOutFee returns an estimate of the fee for the opening transaction.
+// The size is a calculate 2672 bytes for 3 inputs and 3 ouputs of which 2 are
+// blinded. An additional safety margin is added for a total of 3000 bytes.
 func (l *LiquidOnChain) GetFlatSwapOutFee() (uint64, error) {
-	return l.getFee(2587)
+	return l.getFee(3000)
 }
 
 func (l *LiquidOnChain) GetAsset() string {


### PR DESCRIPTION
We adjust the estimated swap-out tx size that is used for fee calculation to 3000 vBytes. The size is based on 3 inputs and 3 outputs of which 2 are blinded (2672 vBytes), together with a security margin.