### PR TITLE
swap: Fix one swap per channel race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ test-liquid-lnd: test-bins
 test-misc-integration: test-bins
 	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} \
 	-run '^('\
+	'Test_OnlyOneActiveSwapPerChannel|'\
 	'Test_GrpcReconnectStream|'\
 	'Test_GrpcRetryRequest|'\
 	'Test_RestoreFromPassedCSV|'\

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,8 @@ test-liquid-lnd: test-bins
 test-misc-integration: test-bins
 	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} \
 	-run '^('\
-	'Test_OnlyOneActiveSwapPerChannel|'\
+	'Test_OnlyOneActiveSwapPerChannelCln|'\
+	'Test_OnlyOneActiveSwapPerChannelLnd|'\
 	'Test_GrpcReconnectStream|'\
 	'Test_GrpcRetryRequest|'\
 	'Test_RestoreFromPassedCSV|'\

--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -138,9 +138,9 @@ func Test_RestoreFromPassedCSV(t *testing.T) {
 		params.origMakerWallet-commitFee-claimFee, balance)
 }
 
-// Test_OnlyOneActiveSwapPerChannel checks that there is only one active swap per 
+// Test_OnlyOneActiveSwapPerChannelCln checks that there is only one active swap per 
 // channel.
-func Test_OnlyOneActiveSwapPerChannel(t *testing.T) {
+func Test_OnlyOneActiveSwapPerChannelCln(t *testing.T) {
 	IsIntegrationTest(t)
 	t.Parallel()
 

--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -3,11 +3,15 @@ package test
 import (
 	"math"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/elementsproject/peerswap/clightning"
+	"github.com/elementsproject/peerswap/peerswaprpc"
 	"github.com/elementsproject/peerswap/swap"
 	"github.com/elementsproject/peerswap/testframework"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +136,95 @@ func Test_RestoreFromPassedCSV(t *testing.T) {
 	require.NoError(err)
 	require.InDelta(params.origMakerWallet-commitFee-claimFee, balance, 1., "expected %d, got %d",
 		params.origMakerWallet-commitFee-claimFee, balance)
+}
+
+// Test_OnlyOneActiveSwapPerChannel checks that there is only one active swap per 
+// channel.
+func Test_OnlyOneActiveSwapPerChannel(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	require := require.New(t)
+
+	bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(6)))
+	defer func() {
+		if t.Failed() {
+			filter := os.Getenv("PEERSWAP_TEST_FILTER")
+			pprintFail(
+				tailableProcess{
+					p:     bitcoind.DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:      lightningds[0].DaemonProcess,
+					filter: filter,
+					lines:  defaultLines,
+				},
+				tailableProcess{
+					p:      lightningds[1].DaemonProcess,
+					filter: filter,
+					lines:  defaultLines,
+				},
+			)
+		}
+	}()
+
+	var channelBalances []uint64
+	var walletBalances []uint64
+	for _, lightningd := range lightningds {
+		b, err := lightningd.GetBtcBalanceSat()
+		require.NoError(err)
+		walletBalances = append(walletBalances, b)
+
+		b, err = lightningd.GetChannelBalanceSat(scid)
+		require.NoError(err)
+		channelBalances = append(channelBalances, b)
+	}
+
+	params := &testParams{
+		swapAmt:          channelBalances[0] / 5,
+		scid:             scid,
+		origTakerWallet:  walletBalances[0],
+		origMakerWallet:  walletBalances[1],
+		origTakerBalance: channelBalances[0],
+		origMakerBalance: channelBalances[1],
+		takerNode:        lightningds[0],
+		makerNode:        lightningds[1],
+		takerPeerswap:    lightningds[0].DaemonProcess,
+		makerPeerswap:    lightningds[1].DaemonProcess,
+		chainRpc:         bitcoind.RpcProxy,
+		chaind:           bitcoind,
+		confirms:         BitcoinConfirms,
+		csv:              BitcoinCsv,
+		swapType:         swap.SWAPTYPE_OUT,
+	}
+	asset := "btc"
+
+	// Do swap. Expect N_SWAPS - 1 errors.
+	wg := sync.WaitGroup{}
+	N_SWAPS := 10
+	var nErr int32
+	for i:=0; i<N_SWAPS; i++ {
+	wg.Add(1)
+	go func(n int) {
+		defer wg.Done()
+		var response map[string]interface{}
+		err := lightningds[0].Rpc.Request(&clightning.SwapOut{SatAmt: params.swapAmt, ShortChannelId: params.scid, Asset: asset}, &response)
+		t.Logf("[%d] Response: %v",n, response)
+		if err != nil {
+			t.Logf("[%d] Err: %s",n, err.Error())
+			atomic.AddInt32(&nErr, 1)
+		}
+	}(i)
+	}
+	wg.Wait()
+
+	var response *peerswaprpc.ListSwapsResponse
+	lightningds[0].Rpc.Request(&clightning.ListActiveSwaps{}, &response)
+	t.Logf("GOT: %v", response)
+
+	assert.EqualValues(t, N_SWAPS-1, nErr, "expected nswaps-1=%d errors, got: %d",N_SWAPS-1, nErr)
+	assert.EqualValues(t, len(response.Swaps), 1, "expected only 1 active swap, got: %d", len(response.Swaps))
 }
 
 func Test_ClnCln_Bitcoin_SwapIn(t *testing.T) {

--- a/test/bitcoin_lnd_test.go
+++ b/test/bitcoin_lnd_test.go
@@ -4,13 +4,117 @@ import (
 	"context"
 	"math"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/elementsproject/peerswap/peerswaprpc"
 	"github.com/elementsproject/peerswap/swap"
 	"github.com/elementsproject/peerswap/testframework"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Test_OnlyOneActiveSwapPerChannelLnd checks that there is only one active swap per
+// channel.
+func Test_OnlyOneActiveSwapPerChannelLnd(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+	require := require.New(t)
+
+	bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
+	defer func() {
+		if t.Failed() {
+			pprintFail(
+				tailableProcess{
+					p:     bitcoind.DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:     lightningds[0].DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:     lightningds[1].DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:     peerswapds[0].DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:     peerswapds[1].DaemonProcess,
+					lines: defaultLines,
+				},
+			)
+		}
+	}()
+
+	var channelBalances []uint64
+	var walletBalances []uint64
+	for _, lightningd := range lightningds {
+		b, err := lightningd.GetBtcBalanceSat()
+		require.NoError(err)
+		walletBalances = append(walletBalances, b)
+
+		b, err = lightningd.GetChannelBalanceSat(scid)
+		require.NoError(err)
+		channelBalances = append(channelBalances, b)
+	}
+
+	lcid, err := lightningds[0].ChanIdFromScid(scid)
+	if err != nil {
+		t.Fatalf("lightingds[0].ChanIdFromScid() %v", err)
+	}
+
+	params := &testParams{
+		swapAmt:          channelBalances[0] / 5,
+		scid:             scid,
+		origTakerWallet:  walletBalances[0],
+		origMakerWallet:  walletBalances[1],
+		origTakerBalance: channelBalances[0],
+		origMakerBalance: channelBalances[1],
+		takerNode:        lightningds[0],
+		makerNode:        lightningds[1],
+		takerPeerswap:    peerswapds[0].DaemonProcess,
+		makerPeerswap:    peerswapds[1].DaemonProcess,
+		chainRpc:         bitcoind.RpcProxy,
+		chaind:           bitcoind,
+		confirms:         BitcoinConfirms,
+		swapType:         swap.SWAPTYPE_IN,
+	}
+	asset := "btc"
+
+	// Do swap. Expect N_SWAPS - 1 errors.
+	wg := sync.WaitGroup{}
+	N_SWAPS := 10
+	var nErr int32
+	ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+	for i:=0; i<N_SWAPS; i++ {
+	wg.Add(1)
+	go func(n int) {
+		defer wg.Done()
+		res, err := peerswapds[1].PeerswapClient.SwapIn(ctx, &peerswaprpc.SwapInRequest{
+			ChannelId:  lcid,
+			SwapAmount: params.swapAmt,
+			Asset:      asset,
+		})
+		t.Logf("[%d] Response: %v",n, res)
+		if err != nil {
+			t.Logf("[%d] Err: %s",n, err.Error())
+			atomic.AddInt32(&nErr, 1)
+		}
+	}(i)
+	}
+	wg.Wait()
+
+	res, err := peerswapds[1].PeerswapClient.ListActiveSwaps(ctx, &peerswaprpc.ListSwapsRequest{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, N_SWAPS-1, nErr, "expected nswaps-1=%d errors, got: %d",N_SWAPS-1, nErr)
+	assert.EqualValues(t, len(res.Swaps), 1, "expected only 1 active swap, got: %d", len(res.Swaps))
+}
+
 
 func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {
 	IsIntegrationTest(t)


### PR DESCRIPTION
This commit fixes a race condition we had on the concurrent invocation of swaps. The reason was a lock guard that was separated.

checking on the existence of another swap on the same channel and writing the lock entry has to be performed in the same lock.