### PR TITLE
Log errors from "main scope"

### DIFF
--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	glog "log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -45,17 +46,18 @@ const (
 )
 
 func main() {
+	mlog := glog.New(os.Stderr, "", glog.LstdFlags|glog.LUTC)
+
 	// In order to receive panics, we write to stderr to a file
 	closeFileFunc, err := setPanicLogger()
 	if err != nil {
-		log.Infof("Error setting panic log file: %s", err) // !: this is completely useless
+		mlog.Println(err.Error())
 		os.Exit(1)
 	}
 	defer closeFileFunc()
 
 	if err := outer(); err != nil {
-		// todo: Log to panic log (std.err)
-		log.Infof("plugin quitting, error: %s", err) // !: this is completely useless
+		mlog.Println(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
We had a hard time debugging certain errors as the cln logs only reported `plugin-peerswap-plugin: Killing plugin: exited during normal operation`. The reason for this was that the errors could not be passed to the cln log as the errors escaped the scope that handled the json rpc connection and messaging to core lightning.

This PR adds logs to errors that are thrown in the `run()` routine. Therefore we add a wrapper around `run()` that initializes the plugin and can use the json rpc interface to log an error that is thrown by peerswap.