### PR TITLE
Change oreder of parameters in cln swap commands

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -184,8 +184,8 @@ func (s *LiquidSendToAddress) LongDescription() string {
 
 // SwapOut starts a new swapout (paying an Invoice for onchain liquidity)
 type SwapOut struct {
-	SatAmt         uint64            `json:"amt_sat"`
 	ShortChannelId string            `json:"short_channel_id"`
+	SatAmt         uint64            `json:"amt_sat"`
 	Asset          string            `json:"asset"`
 	Force          bool              `json:"force"`
 	cl             *ClightningClient `json:"-"`
@@ -302,8 +302,8 @@ func (g *SwapOut) Get(client *ClightningClient) jrpc2.ServerMethod {
 
 // SwapIn Starts a new swap in(providing onchain liquidity)
 type SwapIn struct {
-	SatAmt         uint64 `json:"amt_sat"`
 	ShortChannelId string `json:"short_channel_id"`
+	SatAmt         uint64 `json:"amt_sat"`
 	Asset          string `json:"asset"`
 	Force          bool   `json:"force"`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,12 +56,12 @@ A swap-out is when the initiator wants to pay a lightning payment in order to re
 
 For CLN:
 ```bash
-swap-out [amount in sats] [short channel id] [asset: btc or lbtc]
+swap-out [short channel id] [amount in sats] [asset: btc or lbtc]
 ```
 
 For LND:
 ```bash
-swapout --sat_amt [amount in sats] --channel-id [chan_id] --asset [btc or lbtc]
+swapout --channel-id [chan_id] --sat_amt [amount in sats] --asset [btc or lbtc]
 ```
 
 ### Swap-In
@@ -70,12 +70,12 @@ A swap-in is when the initiator wants to spend onchain bitcoin in order to recei
 
 For CLN:
 ```bash
-swap-in [amount in sats] [short channel id] [asset: btc or lbtc]
+swap-in [short channel id] [amount in sats] [asset: btc or lbtc]
 ```
 
 For LND:
 ```bash
-swapin --sat_amt [amount in sats] --channel_id [chan_id] --asset [btc or lbtc]
+swapin --channel_id [chan_id] --sat_amt [amount in sats] --asset [btc or lbtc]
 ```
 
 


### PR DESCRIPTION
Cln prefers the short channel id at first parameter, we follow this to avoid confusion.