### PR TITLE
Reduce unconnected peer log spam

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -497,7 +497,9 @@ func (cl *ClightningClient) GetPeers() []string {
 
 	var peerlist []string
 	for _, peer := range peers {
-		peerlist = append(peerlist, peer.Id)
+		if peer.Connected {
+			peerlist = append(peerlist, peer.Id)
+		}
 	}
 	return peerlist
 }

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -136,6 +136,7 @@ func NewClightningClient(ctx context.Context) (*ClightningClient, <-chan interfa
 	cl.Plugin.SubscribeConnect(cl.OnConnect)
 
 	cl.glightning = glightning.NewLightning()
+	cl.glightning.SetTimeout(40)
 
 	// we disable feature bit for now as lnd does not support it anyway
 	//b := big.NewInt(0)


### PR DESCRIPTION
This log was related to sending out poll messages to our peers. If a peer is not connected there is no need in sending a message to it. We only care about connected peers and stop sending these messages to knowingly unconnected peers to reduce log spam.
