### PR TITLE
More descriptive `--large-channel` error message

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -180,6 +180,12 @@ func (cl *ClightningClient) CanSpend(amtMsat uint64) error {
 	return nil
 }
 
+// Implementation returns the name of the lightning network client 
+// implementation.
+func (cl *ClightningClient) Implementation() string {
+	return "CLN"
+}
+
 // CheckChannel checks if a channel is eligable for a swap
 func (cl *ClightningClient) CheckChannel(channelId string, amountSat uint64) error {
 	funds, err := cl.glightning.ListFunds()

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -77,6 +77,12 @@ func (l *Client) CanSpend(amtMsat uint64) error {
 	return nil
 }
 
+// Implementation returns the name of the lightning network client 
+// implementation.
+func (l *Client) Implementation() string {
+	return "LND"
+}
+
 func (l *Client) StartListening() error {
 	return l.messageListener.Start()
 }

--- a/swap/service.go
+++ b/swap/service.go
@@ -436,10 +436,11 @@ func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, mes
 
 	err := s.swapServices.lightning.CanSpend(message.Amount * 1000)
 	if err != nil {
+		msg := fmt.Sprintf("from the %s peer: %s", s.swapServices.lightning.Implementation(), err.Error())
 		// We want to tell our peer why we can not do this swap.
 		msgBytes, msgType, err := MarshalPeerswapMessage(&CancelMessage{
 			SwapId:  swapId,
-			Message: err.Error(),
+			Message: msg,
 		})
 		s.swapServices.messenger.SendMessage(peerId, msgBytes, msgType)
 		return err

--- a/swap/services.go
+++ b/swap/services.go
@@ -47,6 +47,7 @@ type LightningClient interface {
 	AddPaymentNotifier(swapId string, payreq string, invoiceType InvoiceType)
 	RebalancePayment(payreq string, channel string) (preimage string, err error)
 	CanSpend(amountMsat uint64) error
+	Implementation() string
 }
 
 type TxWatcher interface {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -256,6 +256,10 @@ type dummyLightningClient struct {
 	canSpendCalled int
 }
 
+func (d *dummyLightningClient) Implementation() string {
+	return "dummy"
+}
+
 func (d *dummyLightningClient) CanSpend(amtMsat uint64) error {
 	d.canSpendCalled++
 	return d.canSpendError

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -72,7 +72,7 @@ func Test_Wumbo(t *testing.T) {
 			largeChannelsEnabled: false,
 			swapAmtSat:           maxPaymentSize + 1,
 			swapType:             swap.SWAPTYPE_IN,
-			expectedError:        fmt.Errorf("-1:swap canceled, reason: swap amount is 4294968000: need to enable option '--large-channels' to swap amounts larger than 2^32 msat"),
+			expectedError:        fmt.Errorf("-1:swap canceled, reason: from the CLN peer: swap amount is 4294968000: need to enable option '--large-channels' to swap amounts larger than 2^32 msat"),
 		},
 		{
 			description:          "in_lc_max",


### PR DESCRIPTION
The error we return when we receive an swap-in request that we can not accept becaus of a missing `--large-channel` flag was confusing for lnd peers, as they don't know this option.
We are now more specific about this.

resolves #166 