### PR TITLE
Rename peerswap-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,10 @@ dist/
 .ci/docker/liquid-config2/**
 
 # build output
-peerswap-plugin
+peerswap
 out/peerswapd
-out/peerswap-plugin
+out/peerswap
 out/pscli
 out/test-builds/peerswapd
-out/test-builds/peerswap-plugin
+out/test-builds/peerswap
 out/test-builds/pscli

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,9 @@ clean-cln:
 	# PeerSwap CLN builds
 	rm -f peerswap
 	rm -f out/peerswap
+	# Purge pre-rename binaries
+	rm -f peerswap-plugin
+	rm -f out/peerswap-plugin
 .PHONY: clean-cln
 
 clean-lnd:

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ INTEGRATION_TEST_OPTS= \
 BINS= \
 	${OUTDIR}/peerswapd \
 	${OUTDIR}/pscli \
-	${OUTDIR}/peerswap-plugin \
+	${OUTDIR}/peerswap \
 
 TEST_BINS= \
 	${TEST_BIN_DIR}/peerswapd \
 	${TEST_BIN_DIR}/pscli \
-	${TEST_BIN_DIR}/peerswap-plugin \
+	${TEST_BIN_DIR}/peerswap \
 
 .PHONY: subdirs ${BINS} ${TEST_BINS}
 
@@ -55,9 +55,9 @@ ${OUTDIR}/pscli:
 	go build ${BUILD_OPTS} -o ${OUTDIR}/pscli ./cmd/peerswaplnd/pscli
 	chmod a+x out/pscli
 
-${OUTDIR}/peerswap-plugin:
-	go build ${BUILD_OPTS} -o ${OUTDIR}/peerswap-plugin ./cmd/peerswap-plugin
-	chmod a+x out/peerswap-plugin
+${OUTDIR}/peerswap:
+	go build ${BUILD_OPTS} -o ${OUTDIR}/peerswap ./cmd/peerswap
+	chmod a+x out/peerswap
 
 ${TEST_BIN_DIR}/peerswapd:
 	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/peerswapd ./cmd/peerswaplnd/peerswapd
@@ -67,9 +67,9 @@ ${TEST_BIN_DIR}/pscli:
 	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/pscli ./cmd/peerswaplnd/pscli
 	chmod a+x ${TEST_BIN_DIR}/pscli
 
-${TEST_BIN_DIR}/peerswap-plugin:
-	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/peerswap-plugin ./cmd/peerswap-plugin
-	chmod a+x ${TEST_BIN_DIR}/peerswap-plugin
+${TEST_BIN_DIR}/peerswap:
+	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/peerswap ./cmd/peerswap
+	chmod a+x ${TEST_BIN_DIR}/peerswap
 
 # Test section. Has commads for local and ci testing.
 test:
@@ -141,15 +141,15 @@ lnd-release: clean-lnd
 .PHONY: lnd-release
 
 cln-release: clean-cln
-	# peerswap-plugin binary is not installed in GOPATH because it must be called by full pathname as a CLN plugin.
+	# peerswap binary is not installed in GOPATH because it must be called by full pathname as a CLN plugin.
 	# You may choose to install it to any location you wish.
-	go build -o peerswap-plugin -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswap-plugin/main.go
+	go build -o peerswap -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswap/main.go
 .PHONY: cln-release
 
 clean-cln:
 	# PeerSwap CLN builds
-	rm -f peerswap-plugin
-	rm -f out/peerswap-plugin
+	rm -f peerswap
+	rm -f out/peerswap
 .PHONY: clean-cln
 
 clean-lnd:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ${OUTDIR}/pscli:
 	chmod a+x out/pscli
 
 ${OUTDIR}/peerswap:
-	go build ${BUILD_OPTS} -o ${OUTDIR}/peerswap ./cmd/peerswap
+	go build ${BUILD_OPTS} -o ${OUTDIR}/peerswap ./cmd/peerswap-plugin
 	chmod a+x out/peerswap
 
 ${TEST_BIN_DIR}/peerswapd:
@@ -68,7 +68,7 @@ ${TEST_BIN_DIR}/pscli:
 	chmod a+x ${TEST_BIN_DIR}/pscli
 
 ${TEST_BIN_DIR}/peerswap:
-	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/peerswap ./cmd/peerswap
+	go build ${TEST_BUILD_OPTS} -o ${TEST_BIN_DIR}/peerswap ./cmd/peerswap-plugin
 	chmod a+x ${TEST_BIN_DIR}/peerswap
 
 # Test section. Has commads for local and ci testing.
@@ -143,7 +143,7 @@ lnd-release: clean-lnd
 cln-release: clean-cln
 	# peerswap binary is not installed in GOPATH because it must be called by full pathname as a CLN plugin.
 	# You may choose to install it to any location you wish.
-	go build -o peerswap -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswap/main.go
+	go build -o peerswap -ldflags "-X main.GitCommit=$(GIT_COMMIT)" ./cmd/peerswap-plugin/main.go
 .PHONY: cln-release
 
 clean-cln:

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -98,7 +98,7 @@ EOF
       ${LIGHTNINGD}\
       --lightning-dir="${dir}" \
       --daemon \
-      --plugin="$(pwd)/out/peerswap-plugin" \
+      --plugin="$(pwd)/out/peerswap" \
       --peerswap-elementsd-rpchost="http://127.0.0.1" \
       --peerswap-elementsd-rpcport="${LIQUID_RPC_PORT}" \
       --peerswap-elementsd-rpcuser=admin1 \

--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -20,7 +20,7 @@ cd peerswap
 make cln-release
 ```
 
-The `peerswap-plugin` binary is now located in the repo folder.
+The `peerswap` binary is now located in the repo folder.
 
 
 
@@ -30,11 +30,11 @@ In order to run `peerswap` add following lines to your the core-lightning config
 
 
 ```bash
-plugin=/PATH/TO/peerswap-plugin
-log-level=debug:plugin-peerswap-plugin
+plugin=/PATH/TO/peerswap
+log-level=debug:plugin-peerswap
 ```
 
-Specify the full path to the `peerswap-plugin` binary. For now it is recommended to log all debug messages from peerswap.
+Specify the full path to the `peerswap` binary. For now it is recommended to log all debug messages from peerswap.
 
 Peerswap will automatically try to connect to your bitcoind and (if available) elementsd
 
@@ -74,12 +74,12 @@ This can be done manually by adding a line with `allowlisted_peers=<REPLACE_WITH
 
 __WARNING__: One could set the `accept_all_peers=true` policy to ignore the allowlist and allow all peers with direct channels to send swap requests.
 
-### Debugging peerswap-plugin crashes
+### Debugging peerswap crashes
 
-Currently if `peerswap-plugin` crashes looks like this in lightningd's log.
+Currently if `peerswap` crashes looks like this in lightningd's log.
 
 ```
-INFO    plugin-peerswap-plugin: Killing plugin: exited during normal operation
+INFO    plugin-peerswap: Killing plugin: exited during normal operation
 ```
 
 When this happens you can find the traceback in `~/.lightning/bitcoin/peerswap/peerswap-panic-log`. Look at the file timestap to confirm it corresponds to the current crash. When you report an issue please include your CLN version, PeerSwap githash, this crash traceback, peerswap log messages during the event, and any other relevant details of what led to the failure.

--- a/docs/signetguide_cln.md
+++ b/docs/signetguide_cln.md
@@ -214,7 +214,7 @@ lightningd --daemon \
 Or with liquid enabled
 ```bash
 lightningd --daemon \
-        --plugin=$HOME/peerswap/peerswap-plugin \
+        --plugin=$HOME/peerswap/peerswap \
         --peerswap-elementsd-rpchost=http://localhost \
         --peerswap-elementsd-rpcport=18884 \
         --peerswap-elementsd-rpcuser=admin1 \

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -12,12 +12,12 @@ If no swaps are returned you can safely upgrade peerswap.
 ### Restarting LND peerswapd
  - lnd: `pscli stop; /PATH/TO/peerswapd`
 
-### Restarting CLN peerswap-plugin
-Due to [CLN issue #5294](https://github.com/ElementsProject/lightning/issues/5294) it is recommended that you fully restart `lightningd` in order to restart peerswap. If you do not rely on CLN to pass any config parameters to peerswap then it is safe to restart peerswap-plugin without touching CLN.
+### Restarting CLN peerswap
+Due to [CLN issue #5294](https://github.com/ElementsProject/lightning/issues/5294) it is recommended that you fully restart `lightningd` in order to restart peerswap. If you do not rely on CLN to pass any config parameters to peerswap then it is safe to restart peerswap without touching CLN.
 
 
  - cln full restart: `lightning-cli stop; /PATH/TO/lightningd`
- - peerswap-plugin restart without lightningd config options: `lightning-cli plugin stop peerswap-plugin; lightning-cli plugin start /PATH/TO/peerswap-plugin`
+ - peerswap restart without lightningd config options: `lightning-cli plugin stop peerswap; lightning-cli plugin start /PATH/TO/peerswap`
 
 Restarting PeerSwap does not affect the accompanying CLN or LND node.
 

--- a/test/setup.go
+++ b/test/setup.go
@@ -40,7 +40,7 @@ func clnclnSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*t
 func clnclnSetupWithConfig(t *testing.T, fundAmt uint64, clnConf []string) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
-	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap-plugin")
+	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 2 lightningd)
@@ -193,7 +193,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	peerswapdPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswapd")
-	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap-plugin")
+	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 cln, 1 lnd, 1 peerswapd)
@@ -305,7 +305,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, *testframework.LiquidNode, []*CLightningNodeWithLiquid, string) {
 	/// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
-	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap-plugin")
+	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 liquidd, 2 lightningd)
@@ -535,7 +535,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	peerswapdPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswapd")
-	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap-plugin")
+	peerswapPluginPath := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
 	testDir := t.TempDir()
 
 	// Setup nodes (1 bitcoind, 1 liquid, 1 cln, 1 lnd, 1 peerswapd)


### PR DESCRIPTION
This changes the name of the `peerswap-plugin` binary to `peerswap` and addresses #72. 