### PR TITLE
Update dependencies and fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,45 +11,39 @@ env:
   SLOW_MACHINE: 1
 
 jobs:
-  buildandtest:
+  build:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@v2
-      
-      - name: Cache install Nix packages
-        uses: rikhuijzer/cache-install@v1.0.8        
+      - name: Checkout code 
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          key: nix-${{ hashFiles('packages.nix') }}
-          nix_file: 'ci.nix'
-      
-      - name: Build peerswap
+          go-version: 1.18
+        
+      - name: Build
         run: make bins
 
-      - name: Run go tests
+      - name: Test
         run: make test
 
-  integration:
+  integration-tests:
     runs-on: ubuntu-latest
-    needs: [buildandtest]
+    needs: [build]
     strategy:
-      max-parallel: 4
       matrix:
-        test-vector: [
-          bitcoin-cln,
-          bitcoin-lnd,
-          liquid-cln,
-          liquid-lnd,
-          misc-integration
-          ]
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Cache install Nix packages
-        uses: rikhuijzer/cache-install@v1.0.8        
-        with:
-          key: nix-${{ hashFiles('packages.nix') }}
-          nix_file: 'ci.nix'
+        test-vector: [bitcoin-cln, bitcoin-lnd, liquid-cln, liquid-lnd, misc-integration]
 
-      - name: Run tests with integration
-        run: make test-${{matrix.test-vector}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Run tests
+        run: nix-shell --run "make test-${{matrix.test-vector}}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   SLOW_MACHINE: 1
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,7 +31,6 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    needs: [build]
     strategy:
       matrix:
         test-vector: [bitcoin-cln, bitcoin-lnd, liquid-cln, liquid-lnd, misc-integration]
@@ -39,11 +38,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      
+      - name: "Cache Nix store"
+        uses: actions/cache@v3.0.8
+        id: nix-cache
+        with:
+          path: /tmp/nixcache
+          key: nix-${{ hashFiles('packages.nix') }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+      
+      - name: "Import Nix store cache"
+        if: "steps.nix-cache.outputs.cache-hit == 'true'"
+        run: "nix-store --import < /tmp/nixcache"
 
       - name: Run tests
         run: nix-shell --run "make test-${{matrix.test-vector}}"
+
+      - name: "Export Nix store cache"
+        if: "steps.nix-cache.outputs.cache-hit != 'true'"
+        run: "nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nixcache"

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -182,7 +182,7 @@ func (l *LiquidOnChain) CreateCoopSpendingTransaction(swapParams *swap.OpeningPa
 	if err != nil {
 		return "", "", err
 	}
-	refundFee, err := l.GetRefundFee()
+	refundFee, err := l.getFee(l.getCoopClaimTxSize())
 	if err != nil {
 		return "", "", err
 	}
@@ -403,6 +403,10 @@ func (l *LiquidOnChain) createSpendingTransaction(openingTxHex string, swapAmoun
 
 func (l *LiquidOnChain) getClaimTxSize() int {
 	return 1350
+}
+
+func (l *LiquidOnChain) getCoopClaimTxSize() int {
+	return 1360
 }
 
 func (l *LiquidOnChain) TxIdFromHex(txHex string) (string, error) {

--- a/packages.nix
+++ b/packages.nix
@@ -1,16 +1,13 @@
 let
-# Pinning to revision 0a8826e7582cf357c1248e10653fd946e6570f99 
-# - cln v22.11.1
-# - lnd v0.15.2-beta
-# - bitcoin v23.0
-rev = "0a8826e7582cf357c1248e10653fd946e6570f99";
+# Pinning to revision 5ae751c41b1b78090e4c311f43aa34792599e563 
+# - cln v23.02
+# - lnd v0.15.5-beta
+# - bitcoin v24.0.1
+# - elements v22.1.0
+
+rev = "5ae751c41b1b78090e4c311f43aa34792599e563";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
-
-# Need an lnd v0.15.4-beta for an emergency fix in lnd.
-lndemergencyrev = "991a5ca464eaf59e50f3f0d102f4216f2f9d18f5";
-lndemergencynixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${lndemergencyrev}.tar.gz";
-lndemergencypkgs = import lndemergencynixpkgs {};
 
 # Override priority for bitcoin as /bin/bitcoin_test will
 # confilict with /bin/bitcoin_test from elementsd.
@@ -39,8 +36,8 @@ in with pkgs;
         bitcoin = bitcoin;
         elements = elementsd;
         mermaid = nodePackages.mermaid-cli;
-        lnd = lndemergencypkgs.lnd;
+        lnd = lnd;
     };
-    testpkgs = [ go bitcoin elementsd clightning-dev lndemergencypkgs.lnd ];
-    devpkgs = [ bitcoin elementsd clightning clightning-dev lndemergencypkgs.lnd docker-compose jq nodePackages.mermaid-cli ];
+    testpkgs = [ go bitcoin elementsd clightning-dev lnd ];
+    devpkgs = [ bitcoin elementsd clightning clightning-dev lnd docker-compose jq nodePackages.mermaid-cli ];
 }

--- a/test/liquid_cln_test.go
+++ b/test/liquid_cln_test.go
@@ -772,7 +772,7 @@ func Test_ClnLnd_Liquid_SwapOut(t *testing.T) {
 						lines:  defaultLines,
 					},
 					tailableProcess{
-						p:     lightningds[1].(*testframework.LndNode).DaemonProcess,
+						p:     lightningds[1].(*LndNodeWithLiquid).DaemonProcess,
 						lines: defaultLines,
 					},
 					tailableProcess{


### PR DESCRIPTION
This pr updates our development and ci dependencies to the following versions:
- cln v23.02
- lnd v0.15.5-beta
- bitcoin core v24.0.1
- elements core v22.1.0
This pr also updates the nix github action to the latest version.