### PR TITLE
cln: make Dup3 platform independent

### DIFF
--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -7,12 +7,12 @@ import (
 	glog "log"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/elementsproject/peerswap/isdev"
 	"github.com/elementsproject/peerswap/log"
 	"github.com/elementsproject/peerswap/version"
+	"golang.org/x/sys/unix"
 
 	"github.com/vulpemventures/go-elements/network"
 
@@ -488,7 +488,7 @@ func setPanicLogger() (func() error, error) {
 		return nil, err
 	}
 
-	err = syscall.Dup3(int(panicLogFile.Fd()), int(os.Stderr.Fd()), 0)
+	err = unix.Dup2(int(panicLogFile.Fd()), int(os.Stderr.Fd()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Dup3 is not available on Mac. Use the sys/unix package for a platform independent version.