### PR TITLE
Fix nix shell on darwin

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -47,6 +47,7 @@ start_cln_node() {
     local network="regtest"
     local addr="127.0.0.1:$((7070 + ${id} * 101))"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -128,6 +129,7 @@ stop_cln_node() {
     local prefix="cln-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -156,6 +158,7 @@ remove_cln_node() {
     local prefix="cln-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      negwork="regtest"
     else
       network=${2}
     fi
@@ -175,6 +178,7 @@ setup_cln_network() {
   local n_nodes=2
   local network="regtest"
   if [ -z ${1} ]; then
+    network="regtest"
   else
     network=${1}
   fi
@@ -206,7 +210,7 @@ setup_cln_network() {
     -rpcconnect=127.0.0.1 \
     -rpcport=18443 \
     getblockcount)
-  while; do
+  while true; do
     blockheight1=$(eval ${LIGHTNING_CLI}-1 getinfo | jq -r .'blockheight')
     blockheight2=$(eval ${LIGHTNING_CLI}-2 getinfo | jq -r .'blockheight')
     if [ $blockheight1 -ge $blockcount ] && [ $blockheight2 -ge $blockcount ]; then
@@ -223,7 +227,7 @@ setup_cln_network() {
   generate 12
 
   # Await channel active
-  while; do
+  while true; do
     local state=$(eval ${LIGHTNING_CLI}-1 listfunds | jq -r '.channels[0].state')
     if [ "$state" = "CHANNELD_NORMAL" ]; then
       prefixwith $prefix echo "Channel is active"
@@ -305,6 +309,7 @@ start_lnd_node() {
     local rpc="127.0.0.1:$((10101 + ${id} * 101))"
     local listen="127.0.0.1:$((10102 + ${id} * 101))"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -384,6 +389,7 @@ stop_lnd_node() {
     local prefix="lnd-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -412,6 +418,7 @@ remove_lnd_node() {
     local prefix="lnd-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -431,6 +438,7 @@ setup_lnd_network() {
   local n_nodes=2
   local network="regtest"
   if [ -z ${1} ]; then
+    network="regtest"
   else
     network=${1}
   fi
@@ -447,7 +455,7 @@ setup_lnd_network() {
   done
 
   # Connect nodes
-  while; do
+  while true; do
     prefixwith $prefix echo "Connecting nodes"
     local to=$(eval ${LND_CLI}-2 getinfo | jq -r '.uris[0]')
     eval ${LND_CLI}-1 connect $to > /dev/null
@@ -471,7 +479,7 @@ setup_lnd_network() {
     -rpcconnect=127.0.0.1 \
     -rpcport=18443 \
     getblockcount)
-  while; do
+  while true; do
     blockheight1=$(eval ${LND_CLI}-1 getinfo | jq -r .'block_height')
     blockheight2=$(eval ${LND_CLI}-2 getinfo | jq -r .'block_height')
     if [ $blockheight1 -ge $blockcount ] && [ $blockheight2 -ge $blockcount ]; then
@@ -488,7 +496,7 @@ setup_lnd_network() {
   generate 12 $LND_SETUP_NETWORK
 
   # Await channel active
-  while; do
+  while true; do
     local active=$(eval ${LND_CLI}-1 listchannels | jq -r '.channels[0].active')
     if [ "$active" = "true" ]; then
       prefixwith $prefix echo "Channel is active"
@@ -551,6 +559,7 @@ fund_lnd_node() {
   else
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -575,6 +584,7 @@ start_peerswapd() {
     local id=${1}
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -640,6 +650,7 @@ stop_peerswapd() {
     local prefix="peerswap-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -667,6 +678,7 @@ remove_peerswapd() {
     local prefix="peerswap-${id}"
     local network="regtest"
     if [ -z ${2} ]; then
+      network="regtest"
     else
       network=${2}
     fi
@@ -709,6 +721,7 @@ generate() {
   fi
   local network="regtest"
   if [ -z ${2} ]; then
+    network="regtest"
   else
     network=${2}
   fi

--- a/packages.nix
+++ b/packages.nix
@@ -9,9 +9,14 @@ rev = "5ae751c41b1b78090e4c311f43aa34792599e563";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
 
+# bitcoin v24.0.1 installation breaks on darwin. Temporarily revert to v24.0
+bitcoin-fix-rev = "0a8826e7582cf357c1248e10653fd946e6570f99";
+bitcoin-fix-nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${bitcoin-fix-rev}.tar.gz";
+bitcoin-fix-pkgs = import bitcoin-fix-nixpkgs {};
+
 # Override priority for bitcoin as /bin/bitcoin_test will
 # confilict with /bin/bitcoin_test from elementsd.
-bitcoin = (pkgs.bitcoin.overrideAttrs (attrs: {
+bitcoin = (bitcoin-fix-pkgs.bitcoin.overrideAttrs (attrs: {
     meta = attrs.meta or {} // {
         priority = 0;
     };
@@ -39,5 +44,5 @@ in with pkgs;
         lnd = lnd;
     };
     testpkgs = [ go bitcoin elementsd clightning-dev lnd ];
-    devpkgs = [ bitcoin elementsd clightning clightning-dev lnd docker-compose jq nodePackages.mermaid-cli ];
+    devpkgs = [ go bitcoin elementsd clightning clightning-dev lnd docker-compose jq nodePackages.mermaid-cli ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     alias lncli='${execs.lnd}/bin/lncli'
 
     . ./contrib/startup_regtest.sh
-    setup_alias
+    setup_aliases
     '';
 }


### PR DESCRIPTION
According to #177 the nix-shell failed on darwin. This is due to an compile error for the bitcoin nixpkg on darwin. We revert to version 24.0 to avoid the failing build. 

Update to v24.0.1 again, once the nixpkg builds correctly on darwin x86_64.

Resolves #177 