### PR TITLE
Fix `listpeers` response

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -655,11 +655,10 @@ func (l *ListPeers) Call() (jrpc2.Result, error) {
 			for _, channel := range peer.Channels {
 				if c, ok := fundingChannels[channel.ShortChannelId]; ok {
 					peerSwapPeerChannels = append(peerSwapPeerChannels, &PeerSwapPeerChannel{
-						ChannelId:       c.ShortChannelId,
-						LocalBalance:    c.ChannelSatoshi,
-						RemoteBalance:   uint64(c.ChannelTotalSatoshi - c.ChannelSatoshi),
-						LocalPercentage: float64(c.ChannelSatoshi) / float64(c.ChannelTotalSatoshi),
-						State:           c.State,
+						ChannelId:     c.ShortChannelId,
+						LocalBalance:  c.OurAmountMilliSatoshi.MSat() / 1000,
+						RemoteBalance: (c.AmountMilliSatoshi.MSat() - c.OurAmountMilliSatoshi.MSat()) / 1000,
+						State:         c.State,
 					})
 				}
 			}
@@ -1138,7 +1137,7 @@ type PeerSwapPeer struct {
 	Channels        []*PeerSwapPeerChannel `json:"channels"`
 	AsSender        *SwapStats             `json:"sent,omitempty"`
 	AsReceiver      *SwapStats             `json:"received,omitempty"`
-	PaidFee         uint64                 `json:"total_fee_paid"`
+	PaidFee         uint64                 `json:"total_fee_paid,omitempty"`
 }
 
 // checkFeatures checks if a node runs the peerswap Plugin

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -148,7 +148,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 		return err
 	}
 	if !ok {
-		log.Debugf("Core-lighting version %s is not supported, min version is v%s", nodeInfo.Version, minClnVersion)
+		log.Infof("Core-lighting version %s is not supported, min version is v%s", nodeInfo.Version, minClnVersion)
 		return fmt.Errorf("Core-Lightning version %s is incompatible", nodeInfo.Version)
 	}
 


### PR DESCRIPTION
The response produced an `NaN` error unmarshalling the response. A possible cause could have been the use of deprecated values in a division operation.
This PR changes to the new cln msat values and removes the possible zero division. Everyone can calculate the removed percentage on demand. 