### PR TITLE
Remove payload from log messages

### DIFF
--- a/swap/service.go
+++ b/swap/service.go
@@ -158,7 +158,9 @@ func (s *SwapService) logMsg(swapId, peerId, msgTypeString string, payload []byt
 	// We see the message type for this swap for the first time, we log the
 	// message.
 	s.lastMsgLog[swapId] = msgTypeString
-	log.Debugf("[Messenger] From: %s got msgtype: %s with payload: %s for swap: %s", peerId, msgTypeString, payload, swapId)
+
+	// The payload is omitted because it includes the blinding key.
+	log.Debugf("[Messenger] From: %s got msgtype: %s for swap: %s", peerId, msgTypeString, swapId)
 }
 
 // OnMessageReceived handles incoming valid peermessages


### PR DESCRIPTION
This is a quick hack for keeping the L-BTC blinding key from being logged during a swap. 

Example log:

```
2023-07-12T14:34:16.465Z DEBUG   plugin-peerswap: [Messenger] From: 035ca2fe4793a5e789ce846062eb4834f573c060d9200ce77544a29b48a0aa5923 got msgtype: a45d for swap: 2f5eb4f558a0a2d185fa282769ed2c8d74a3e3f4be47f1deb3a8c9834a00f1a5
```

The swap ID is still printed so CLN users can check `listswaps` (set to `true`) to find the blinding key and other info that otherwise would have been printed to the logs. The LND PeerSwap currently lacks the more detailed `listswaps` option, but they should be able to get the blinding keys from `elements-cli listtransactions`?

Addresses #199