### PR TITLE
WIP - Reduce the Load Induced by the Polling Service

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -748,8 +748,6 @@ func (c ReloadPolicyFile) Call() (jrpc2.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Resend poll
-	c.cl.pollService.PollAllPeers()
 	return c.cl.policy.Get(), nil
 }
 

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -353,7 +353,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	if err != nil {
 		return err
 	}
-	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lightningPlugin, pol, lightningPlugin, supportedAssets)
+	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lightningPlugin, pol, supportedAssets)
 	pollService.Start()
 	defer pollService.Stop()
 

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -357,6 +357,16 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	pollService.Start()
 	defer pollService.Stop()
 
+	// Initially add all known peers to the poll service.
+	go func() {
+		peers := lightningPlugin.GetPeers()
+		for _, peer := range peers {
+			pollService.AddPeer(peer)
+			time.Sleep(1 * time.Second)
+		}
+		log.Infof("Added all peers to the poll service")
+	}()
+
 	sp := swap.NewRequestedSwapsPrinter(requestedSwapStore)
 	lightningPlugin.SetupClients(liquidRpcWallet, swapService, pol, sp, liquidCli, bitcoinCli, bitcoinOnChainService, pollService)
 

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -353,7 +353,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	if err != nil {
 		return err
 	}
-	pollService := poll.NewService(1*time.Hour, 2*time.Hour, pollStore, lightningPlugin, pol, lightningPlugin, supportedAssets)
+	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lightningPlugin, pol, lightningPlugin, supportedAssets)
 	pollService.Start()
 	defer pollService.Stop()
 

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -339,7 +339,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lnd, pol, lnd, supportedAssets)
+	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lnd, pol, supportedAssets)
 	pollService.Start()
 	defer pollService.Stop()
 

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -339,7 +339,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	pollService := poll.NewService(1*time.Hour, 2*time.Hour, pollStore, lnd, pol, lnd, supportedAssets)
+	pollService := poll.NewService(1*time.Second, 2*time.Hour, pollStore, lnd, pol, lnd, supportedAssets)
 	pollService.Start()
 	defer pollService.Stop()
 

--- a/peerswaprpc/server.go
+++ b/peerswaprpc/server.go
@@ -441,7 +441,6 @@ func (p *PeerswapServer) ReloadPolicyFile(ctx context.Context, request *ReloadPo
 	if err != nil {
 		return nil, err
 	}
-	p.pollService.PollAllPeers()
 	pol := p.policy.Get()
 	return GetPolicyMessage(pol), nil
 }

--- a/poll/queue.go
+++ b/poll/queue.go
@@ -1,0 +1,44 @@
+package poll
+
+import (
+	"sync"
+	"time"
+)
+
+type pollQueue = queue[nextPeer]
+
+type nextPeer struct {
+	ts   time.Time
+	peer string
+}
+
+type queue[C any] struct {
+	sync.RWMutex
+	q []C
+}
+
+func (q *queue[C]) Enqueue(elem ...C) {
+	q.Lock()
+	defer q.Unlock()
+	q.q = append(q.q, elem...)
+}
+
+func (q *queue[C]) Peek() (C, bool) {
+	q.RLock()
+	defer q.RUnlock()
+	if len(q.q) > 0 {
+		return q.q[0], true
+	}
+	return *new(C), false
+}
+
+func (q *queue[C]) Dequeue() (C, bool) {
+	q.Lock()
+	defer q.Unlock()
+	if len(q.q) > 0 {
+		elem := q.q[0]
+		q.q = q.q[1:]
+		return elem, true
+	}
+	return *new(C), false
+}

--- a/poll/queue_test.go
+++ b/poll/queue_test.go
@@ -1,0 +1,36 @@
+package poll
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Queue_Enqueue(t *testing.T) {
+	t.Parallel()
+	q := queue[int]{}
+	q.Enqueue(1)
+	assert.Equal(t, 1, len(q.q))
+}
+
+func Test_Queue_Dequeue(t *testing.T) {
+	t.Parallel()
+	q := queue[int]{}
+	q.Enqueue(101)
+	q.Enqueue(102)
+	i, ok := q.Dequeue()
+	assert.True(t, ok)
+	assert.Equal(t, 101, i)
+	assert.Equal(t, 1, len(q.q))
+}
+
+func Test_Queue_Peek(t *testing.T) {
+	t.Parallel()
+	q := queue[int]{}
+	q.Enqueue(101)
+	q.Enqueue(102)
+	i, ok := q.Peek()
+	assert.True(t, ok)
+	assert.Equal(t, 101, i)
+	assert.Equal(t, 2, len(q.q))
+}

--- a/poll/service.go
+++ b/poll/service.go
@@ -297,9 +297,9 @@ func (s *Service) AddPeer(peer string) {
 	defer s.Unlock()
 	if _, ok := s.peerList[peer]; !ok {
 		s.peerList[peer] = struct{}{}
+		s.Poll(peer)
+		s.pollQueue.Enqueue(nextPeer{ts: time.Now().Add(s.pollDelta), peer: peer})
 	}
-	s.Poll(peer)
-	s.pollQueue.Enqueue(nextPeer{ts: time.Now().Add(s.pollDelta), peer: peer})
 }
 
 // RemovePeer removes a peer from the peer list. A peer that is not on the peer

--- a/poll/service_test.go
+++ b/poll/service_test.go
@@ -30,16 +30,6 @@ func (m *MessengerMock) SendMessage(peerId string, message []byte, messageType i
 func (m *MessengerMock) AddMessageHandler(func(peerId string, msgType string, payload []byte) error) {
 }
 
-type PeerGetterMock struct {
-	peers  []string
-	called int
-}
-
-func (m *PeerGetterMock) GetPeers() []string {
-	m.called++
-	return m.peers
-}
-
 type PolicyMock struct {
 	allowList []bool
 	called    uint
@@ -63,17 +53,17 @@ func TestSendMessage(t *testing.T) {
 
 	messenger := &MessengerMock{}
 	policy := &PolicyMock{allowList: []bool{true, false}}
-	peerGetter := &PeerGetterMock{
-		peers: []string{"peer1", "peer2"},
-	}
+
+	peers := []string{"peer1", "peer2"}
+
 	assets := []string{"asset1", "asset2", "asset3"}
-	ps := NewService(500*time.Millisecond, 1*time.Second, store, messenger, policy, peerGetter, assets)
-	for _, peer := range peerGetter.peers {
+	ps := NewService(500*time.Millisecond, 1*time.Second, store, messenger, policy, assets)
+	for _, peer := range peers {
 		ps.Poll(peer)
 	}
 
-	assert.Len(t, messenger.peersReceived, len(peerGetter.peers))
-	assert.ElementsMatch(t, messenger.peersReceived, peerGetter.peers)
+	assert.Len(t, messenger.peersReceived, len(peers))
+	assert.ElementsMatch(t, messenger.peersReceived, peers)
 
 	var msgs []PollMessage
 	for _, msgByte := range messenger.msgReceived {
@@ -101,11 +91,11 @@ func TestRecievePollAndPollRequest(t *testing.T) {
 
 	messenger := &MessengerMock{}
 	policy := &PolicyMock{allowList: []bool{true, false}}
-	peerGetter := &PeerGetterMock{
-		peers: []string{"peer1", "peer2"},
-	}
+
+	// peers := []string{"peer1", "peer2"}
+
 	assets := []string{"asset1", "asset2", "asset3"}
-	ps := NewService(500*time.Millisecond, 1*time.Second, store, messenger, policy, peerGetter, assets)
+	ps := NewService(500*time.Millisecond, 1*time.Second, store, messenger, policy, assets)
 
 	pmt := messages.MessageTypeToHexString(messages.MESSAGETYPE_POLL)
 	rpmt := messages.MessageTypeToHexString(messages.MESSAGETYPE_REQUEST_POLL)


### PR DESCRIPTION
We had some trouble on large nodes sending out all poll messages (see #185), maybe because we tried to send them out concurrently. This PR updates the polling service to use a sequential, time-ordered model to send out the poll messages.
Therefore we add a queue which elements are time ordered and by time we mean the timestamp at which we should send the next message to the peer.

Our main loop now is tick based and checks the following every other second:  
- Does the first peer in queue need a new poll msg sent out (is the timestamp past now)
- If so -> send msg and re-queue with new timestamp
- If not -> wait for next tick and check again

This way we reduce the stress that we put on the node and the network connections.
If this was the cause for the disappearing peers, this resolves #185 