### PR TITLE
improve payment notifier log message

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -118,7 +118,7 @@ func (cl *ClightningClient) AddPaymentNotifier(swapId string, payreq string, inv
 		// either paid or expired.
 		res, err := cl.glightning.WaitInvoice(getLabel(swapId, invoiceType))
 		if err != nil {
-			log.Debugf("[Payment Notifier] Error %v", err)
+			log.Infof("[Payment Notifier] Error %v, swap %s", err, swapId)
 			return
 		}
 


### PR DESCRIPTION
Example:
```
2023-07-29T02:21:24.113Z DEBUG   plugin-peerswap: [Payment Notifier] Error 903:invoice expired during wait
```

This PR is intended to improve the above error message to include the swap ID and change the log level to INFO. 