### PR TITLE
Add CLN config option to disable BTC swaps, fixup LND swap config

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -272,7 +272,7 @@ func (cl *ClightningClient) SetPeerswapConfig(config *Config) {
 		LiquidRpcHost:          config.Liquid.RpcHost,
 		LiquidRpcPort:          config.Liquid.RpcPort,
 		LiquidRpcWallet:        config.Liquid.RpcWallet,
-		LiquidDisabled:         config.Liquid.Disabled,
+		LiquidDisabled:         *config.Liquid.LiquidSwaps,
 		PeerswapDir:            config.PeerswapDir,
 	}
 }

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -412,7 +412,7 @@ func ElementsCookieConnect() Processor {
 	return func(c *Config) (*Config, error) {
 		var err error
 		if c.Liquid.RpcUser == "" && c.Liquid.RpcPassword == "" &&
-			c.Liquid.LiquidSwaps == nil {
+			!*c.Liquid.LiquidSwaps == false {
 			if c.Liquid.RpcPasswordFile == "" {
 				return nil, fmt.Errorf("no liquid rpc configuration found")
 			}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -47,7 +47,7 @@ type LiquidConf struct {
 	RpcWallet       string
 	Network         string
 	DataDir         string
-	Disabled        bool
+	LiquidSwaps     *bool
 }
 
 type Config struct {
@@ -168,7 +168,7 @@ func ReadFromFile() Processor {
 			c.Liquid.RpcHost = fileConf.Liquid.RpcHost
 			c.Liquid.RpcPort = fileConf.Liquid.RpcPort
 			c.Liquid.RpcWallet = fileConf.Liquid.RpcWallet
-			c.Liquid.Disabled = fileConf.Liquid.Disabled
+			c.Liquid.LiquidSwaps = fileConf.Liquid.LiquidSwaps
 		}
 
 		return c, nil
@@ -339,6 +339,11 @@ func ElementsFallback() Processor {
 			}
 			c.Liquid.DataDir = filepath.Join(home, defaultElementsSubDir)
 		}
+		
+		if c.Liquid.LiquidSwaps == nil {
+				var swapson = true
+				c.Liquid.LiquidSwaps = &swapson
+		}		
 
 		if c.Liquid.Network == "" {
 			c.Liquid.Network, err = liquidNetDir(c.Bitcoin.Network)
@@ -407,7 +412,7 @@ func ElementsCookieConnect() Processor {
 	return func(c *Config) (*Config, error) {
 		var err error
 		if c.Liquid.RpcUser == "" && c.Liquid.RpcPassword == "" &&
-			!c.Liquid.Disabled {
+			c.Liquid.LiquidSwaps == nil {
 			if c.Liquid.RpcPasswordFile == "" {
 				return nil, fmt.Errorf("no liquid rpc configuration found")
 			}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -35,6 +35,7 @@ type BitcoinConf struct {
 	RpcPort         uint
 	Network         string
 	DataDir         string
+	BitcoinSwaps	*bool
 }
 
 type LiquidConf struct {
@@ -157,6 +158,7 @@ func ReadFromFile() Processor {
 			c.Bitcoin.RpcPasswordFile = fileConf.Bitcoin.RpcPasswordFile
 			c.Bitcoin.RpcHost = fileConf.Bitcoin.RpcHost
 			c.Bitcoin.RpcPort = fileConf.Bitcoin.RpcPort
+			c.Bitcoin.BitcoinSwaps = fileConf.Bitcoin.BitcoinSwaps
 		}
 
 		if fileConf.Liquid != nil {
@@ -296,7 +298,12 @@ func BitcoinFallback() Processor {
 			}
 			c.Bitcoin.DataDir = filepath.Join(home, defaultBitcoinSubDir)
 		}
-
+		
+		if c.Bitcoin.BitcoinSwaps == nil {
+				var swapson = true
+				c.Bitcoin.BitcoinSwaps = &swapson
+		}
+		
 		if c.Bitcoin.RpcHost == "" {
 			c.Bitcoin.RpcHost = defaultRpcHost
 		}

--- a/clightning/config_test.go
+++ b/clightning/config_test.go
@@ -26,7 +26,6 @@ func Test_ReadFromFile(t *testing.T) {
 	rpchost="rpchost"
 	rpcport=1234
 	rpcwallet="rpcwallet"
-	enabled=true
 	`
 
 	dir := t.TempDir()
@@ -59,7 +58,7 @@ func Test_ReadFromFile(t *testing.T) {
 			RpcWallet:       "rpcwallet",
 			Network:         "",
 			DataDir:         "",
-			Disabled:        false,
+			LiquidSwaps:     nil,
 		},
 	}
 

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -169,7 +169,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	var liquidCli *gelements.Elements
 	var liquidEnabled bool
 
-	if !config.Liquid.Disabled && liquidWanted(config) {
+	if *config.Liquid.LiquidSwaps && liquidWanted(config) {
 		liquidEnabled = true
 		log.Infof("Starting elements client with rpcuser: %s, rpcpassword:******, rpccookie: %s, rpcport: %d, rpchost: %s",
 			config.Liquid.RpcUser,
@@ -276,8 +276,12 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 		log.Infof("Bitcoin swaps disabled")
 	}
 
+	if !*config.Bitcoin.BitcoinSwaps && !*config.Liquid.LiquidSwaps {
+		return errors.New("Disabling both BTC and L-BTC swaps is invalid.")
+	}
+	
 	if !bitcoinEnabled && !liquidEnabled {
-		return errors.New("bad config, either liquid or bitcoin settings must be set")
+		return errors.New("Bad configuration or daemons are broken.")
 	}
 
 	// db

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -228,7 +228,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	var bitcoinTxWatcher *txwatcher.BlockchainRpcTxWatcher
 	var bitcoinOnChainService *onchain.BitcoinOnChain
 	var bitcoinEnabled bool
-	if bitcoinCli != nil {
+	if  bitcoinCli != nil && *config.Bitcoin.BitcoinSwaps {
 		supportedAssets = append(supportedAssets, "btc")
 		log.Infof("Bitcoin swaps enabled")
 		bitcoinEnabled = true

--- a/cmd/peerswaplnd/config.go
+++ b/cmd/peerswaplnd/config.go
@@ -46,14 +46,14 @@ type PeerSwapConfig struct {
 	LndConfig      *LndConfig     `group:"Lnd Grpc config" namespace:"lnd"`
 	ElementsConfig *OnchainConfig `group:"Elements Rpc Config" namespace:"elementsd"`
 
-	LiquidEnabled  bool
+	LiquidEnabled  bool `long:"liquidswaps" description:"enable bitcoin peerswaps"`
 	BitcoinEnabled bool `long:"bitcoinswaps" description:"enable bitcoin peerswaps"`
 }
 
 func (p *PeerSwapConfig) String() string {
 	var liquidString string
 	if p.ElementsConfig != nil {
-		liquidString = fmt.Sprintf("elements: rpcuser: %s, rpchost: %s, rpcport %v, rpcwallet: %s", p.ElementsConfig.RpcUser, p.ElementsConfig.RpcHost, p.ElementsConfig.RpcPort, p.ElementsConfig.RpcWallet)
+		liquidString = fmt.Sprintf("elements: rpcuser: %s, rpchost: %s, rpcport %v, rpcwallet: %s, liquidswaps: %v", p.ElementsConfig.RpcUser, p.ElementsConfig.RpcHost, p.ElementsConfig.RpcPort, p.ElementsConfig.RpcWallet, p.ElementsConfig.LiquidSwaps)
 	}
 	var lndString string
 	if p.LndConfig != nil {
@@ -68,12 +68,14 @@ func (p *PeerSwapConfig) String() string {
 }
 
 func (p *PeerSwapConfig) Validate() error {
-	if p.ElementsConfig.RpcHost != "" {
+	if p.ElementsConfig.RpcHost != "" && p.ElementsConfig.LiquidSwaps != false {
 		err := p.ElementsConfig.Validate()
 		if err != nil {
 			return err
-		}
+		}	
 		p.LiquidEnabled = true
+		
+		
 	}
 	return nil
 }
@@ -86,6 +88,7 @@ type OnchainConfig struct {
 	RpcHost           string `long:"rpchost" description:"host to connect to"`
 	RpcPort           uint   `long:"rpcport" description:"port to connect to"`
 	RpcWallet         string `long:"rpcwallet" description:"wallet to use for swaps (elements only)"`
+	LiquidSwaps	  bool	 `long:"liquidswaps" description:"set to false to disable L-BTC swaps"`
 }
 
 func (o *OnchainConfig) Validate() error {
@@ -156,5 +159,6 @@ func defaultLiquidConfig() *OnchainConfig {
 		RpcHost:           "",
 		RpcPort:           0,
 		RpcWallet:         DefaultLiquidwallet,
+		LiquidSwaps:	   true,
 	}
 }

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -228,8 +228,14 @@ func run() error {
 		log.Infof("Liquid swaps disabled")
 	}
 
+	if !cfg.BitcoinEnabled && !cfg.ElementsConfig.LiquidSwaps {
+		log.Infof("Disabling both BTC and L-BTC swaps is invalid. Check PeerSwap and daemon configs. Exiting.")
+		os.Exit(1)
+	}
+	
 	if !cfg.BitcoinEnabled && !cfg.LiquidEnabled {
-		return errors.New("bad config, either liquid or bitcoin settings must be set")
+		log.Infof("Bad configuration or daemons are broken. Exiting.")
+		os.Exit(1)
 	}
 	// Start lnd listeners and watchers.
 	messageListener, err := lnd_internal.NewMessageListener(ctx, cc)

--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -70,7 +70,7 @@ rpchost="host"
 rpcport=1234
 rpcpasswordfile="/path/to/auth/.cookie" ## If set this will be used for authentication
 rpcwallet="swap-wallet" ## (default: peerswap)
-enabled=false ## If set to true, peerswap connects to elementsd
+liquidswaps=true ## If set to false, L-BTC swaps are disabled
 ```
 
 In order to check if your daemon is setup correctly run

--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -59,6 +59,7 @@ rpcpassword="password"
 rpchost="host"
 rpcport=1234
 cookiefilepath="/path/to/auth/.cookie" ## If set this will be used for authentication
+bitcoinswaps=false ## If set to false, BTC mainchain swaps are disabled
 
 # Liquid section
 # Liquid rpc connection settings.

--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -59,7 +59,7 @@ rpcpassword="password"
 rpchost="host"
 rpcport=1234
 cookiefilepath="/path/to/auth/.cookie" ## If set this will be used for authentication
-bitcoinswaps=false ## If set to false, BTC mainchain swaps are disabled
+bitcoinswaps=true ## If set to false, BTC mainchain swaps are disabled
 
 # Liquid section
 # Liquid rpc connection settings.

--- a/docs/setup_lnd.md
+++ b/docs/setup_lnd.md
@@ -56,8 +56,26 @@ elementsd.rpcpass=<REPLACE_ME>
 elementsd.rpchost=http://127.0.0.1
 elementsd.rpcport=<REPLACE_ME>
 elementsd.rpcwallet=peerswap
+elementsd.liquidswaps=true # set to false to manually disable L-BTC swaps
 EOF
 ```
+
+L-BTC only config. 
+
+```bash
+cat <<EOF > ~/.peerswap/peerswap.conf
+
+bitcoinswaps=false # disables BTC swaps
+lnd.tlscertpath=/home/<username>/.lnd/tls.cert
+lnd.macaroonpath=/home/<username>/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
+elementsd.rpcuser=<REPLACE_ME>
+elementsd.rpcpass=<REPLACE_ME>
+elementsd.rpchost=http://127.0.0.1
+elementsd.rpcport=<REPLACE_ME>
+elementsd.rpcwallet=peerswap
+EOF
+```
+
 ### Policy
 
 On first startup of the plugin a policy file will be generated (default path: `~/.peerswap/policy.conf`) in which trusted nodes will be specified.

--- a/swap/service.go
+++ b/swap/service.go
@@ -149,7 +149,7 @@ func (s *SwapService) RecoverSwaps() error {
 			}
 		}(sw)
 	}
-	log.Debugf("Waiting for all open swaps to recover.")
+	log.Debugf("Waiting for all pending swaps to recover.")
 	wg.Wait()
 	return nil
 }


### PR DESCRIPTION
This adds a config option for the `[Bitcoin]` section in `peerswap.conf` that disables BTC mainchain swaps so nodes can choose to only swap L-BTC if they desire. The existing behavior of enabling BTC swaps if there are no config options set, or if `peerswap.conf` doesn't exist, is also maintained. 

Example:
```
[Bitcoin]
bitcoinswaps=false
```
