### PR TITLE
cln: bitcoin-rpcport is now an int in CLN 23.08

### DIFF
--- a/clightning/config.go
+++ b/clightning/config.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/elementsproject/glightning/glightning"
@@ -273,11 +272,7 @@ func BitcoinFallbackFromClnConfig(client *ClightningClient) Processor {
 					}
 					if v, ok := plugin.Options["bitcoin-rpcport"]; ok {
 						if v != nil {
-							port, err := strconv.Atoi(v.(string))
-							if err != nil {
-								return nil, err
-							}
-							c.Bitcoin.RpcPort = uint(port)
+							c.Bitcoin.RpcPort = uint(v.(float64))
 						}
 					}
 				}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"strconv"
-	"reflect"
 	"github.com/elementsproject/glightning/glightning"
 	"github.com/elementsproject/peerswap/log"
 	"github.com/pelletier/go-toml/v2"
@@ -285,7 +284,6 @@ func BitcoinFallbackFromClnConfig(client *ClightningClient) Processor {
 							        c.Bitcoin.RpcPort = uint(p)
 							default:
 							        return nil, fmt.Errorf("Bitcoind rpcport type %T not handled", v)
-							}
 							}
 						}
 					}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -274,14 +274,18 @@ func BitcoinFallbackFromClnConfig(client *ClightningClient) Processor {
 					if v, ok := plugin.Options["bitcoin-rpcport"]; ok {
 						if v != nil {
 							// detect if type is string (CLN < v23.08)
-							if reflect.TypeOf(v).String() == "string" {
-								port, err := strconv.Atoi(v.(string))
+							switch p := v.(type) {
+							case string:
+							        port, err := strconv.Atoi(p)
 								if err != nil {
 									return nil, err
-								c.Bitcoin.RpcPort = uint(port)
-								}
-							} else {
-								c.Bitcoin.RpcPort = uint(v.(float64))
+							        }
+							        c.Bitcoin.RpcPort = uint(port)
+							case float64:
+							        c.Bitcoin.RpcPort = uint(p)
+							default:
+							        return nil, fmt.Errorf("Bitcoind rpcport type %T not handled", v)
+							}
 							}
 						}
 					}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
+	"strconv"
+	"reflect"
 	"github.com/elementsproject/glightning/glightning"
 	"github.com/elementsproject/peerswap/log"
 	"github.com/pelletier/go-toml/v2"
@@ -272,7 +273,16 @@ func BitcoinFallbackFromClnConfig(client *ClightningClient) Processor {
 					}
 					if v, ok := plugin.Options["bitcoin-rpcport"]; ok {
 						if v != nil {
-							c.Bitcoin.RpcPort = uint(v.(float64))
+							// detect if type is string (CLN < v23.08)
+							if reflect.TypeOf(v).String() == "string" {
+								port, err := strconv.Atoi(v.(string))
+								if err != nil {
+									return nil, err
+								c.Bitcoin.RpcPort = uint(port)
+								}
+							} else {
+								c.Bitcoin.RpcPort = uint(v.(float64))
+							}
 						}
 					}
 				}


### PR DESCRIPTION
`bitcoin-rpcport` is now an integer in CLN 23.08. Go unmarshals JSON numbers into a `float64` by default, so we need to convert that to a `uint` to make PeerSwap happy. 

Should fix #225.