### PR TITLE
Add new lnd error message to the `retry` middleware

### DIFF
--- a/lnd/connect.go
+++ b/lnd/connect.go
@@ -74,6 +74,10 @@ var (
 			Code: codes.Unimplemented,
 			Msg:  "Not Found: HTTP status code 404; transport: received the unexpected content-type \"text/plain; charset=utf-8\"",
 		},
+		{
+			Code: codes.Unknown,
+			Msg:  "server is still in the process of starting",
+		},
 	}
 )
 


### PR DESCRIPTION
We found a LND error messsage that tells us that the server/service is still starting up and that we did not know about until now.