### PR TITLE
delete the comment of old issue link

### DIFF
--- a/swap/actions.go
+++ b/swap/actions.go
@@ -366,7 +366,6 @@ func (c *CreateSwapOutFromRequestAction) Execute(services *SwapServices, swap *S
 		return swap.HandleError(err)
 	}
 
-	// todo replace with premium estimation https://github.com/elementsproject/peerswap/issues/109
 	openingFee, err := wallet.GetFlatSwapOutFee()
 	if err != nil {
 		swap.LastErr = err


### PR DESCRIPTION
This comment seems to be about issue https://github.com/elementsproject/peerswap/issues/110, not https://github.com/elementsproject/peerswap/issues/109.  
https://github.com/elementsproject/peerswap/issues/110 is already closed, but I think the premium feature specifications have not been determined.

I think it would be better to reopen https://github.com/elementsproject/peerswap/issues/110 or create a separate issue for the premium feature.

If a separate issue is created, I'll re-modify the link to a new one.