### PR TITLE
config: add function to detect allow-deprecated-apis=false in CLN config

### DIFF
--- a/clightning/config.go
+++ b/clightning/config.go
@@ -117,7 +117,7 @@ func CheckForDeprecatedApiConfig(client *ClightningClient) Processor {
 		x := listConfigResponse["configs"].(map[string]interface{})["allow-deprecated-apis"]
 		z := x.(map[string]interface{})["value_bool"]
 		if z == false {
-			log.Infof("WARNING: allow-deprecated-apis=false detected in CLN config. Exiting")
+			log.Infof("WARNING: allow-deprecated-apis=false detected in CLN config. Exiting. More info: https://github.com/ElementsProject/peerswap/issues/232")
 			time.Sleep(1 * time.Second)
 			os.Exit(1)
 		}


### PR DESCRIPTION
This adds a function `CheckForDeprecatedApiConfig()` to `clightning/config.go` to check if `allow-deprecated-apis` is set to `false` in the CLN config. This is because setting that option false turns off deprecated, but not yet fully removed, API fields that PeerSwap may rely on. If we detect it is set `false` then we print a warning and exit the plugin to be safe.

Resolves #228 