### PR TITLE
Add additional sanity checks before starting a swap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ test-bitcoin-cln: test-bins
 	'Test_ClnCln_Bitcoin_SwapOut|'\
 	'Test_ClnCln_Bitcoin_SwapIn|'\
 	'Test_ClnLnd_Bitcoin_SwapOut|'\
-	'Test_ClnLnd_Bitcoin_SwapIn)'\
+	'Test_ClnLnd_Bitcoin_SwapIn|'\
+	'Test_ClnCln_ExcessiveAmount)'\
 	 ./test
 .PHONY: test-bitoin-cln
 

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -211,6 +211,7 @@ func (r ListPeerChannelsRequest) Name() string {
 // SpendableMsat returns an estimate of the total we could send through the
 // channel with given scid. Falls back to the owned amount in the channel.
 func (cl *ClightningClient) SpendableMsat(scid string) (uint64, error) {
+	scid = lightning.Scid(scid).ClnStyle()
 	var res struct {
 		Channels []struct {
 			ShortChannelId string            `json:"short_channel_id,omitempty"`
@@ -237,6 +238,7 @@ func (cl *ClightningClient) SpendableMsat(scid string) (uint64, error) {
 // ReceivableMsat returns an estimate of the total we could receive through the
 // channel with given scid.
 func (cl *ClightningClient) ReceivableMsat(scid string) (uint64, error) {
+	scid = lightning.Scid(scid).ClnStyle()
 	var res struct {
 		Channels []struct {
 			ShortChannelId string            `json:"short_channel_id,omitempty"`

--- a/swap/service.go
+++ b/swap/service.go
@@ -444,6 +444,11 @@ func (s *SwapService) SwapIn(peer string, chain string, channelId string, initia
 		return nil, ErrMinimumSwapSize(s.swapServices.policy.GetMinSwapAmountMsat())
 	}
 
+	err := s.swapServices.lightning.CanSpend(amtSat * 1000)
+	if err != nil {
+		return nil, err
+	}
+
 	rs, err := s.swapServices.lightning.ReceivableMsat(channelId)
 	if err != nil {
 		return nil, err

--- a/swap/service.go
+++ b/swap/service.go
@@ -444,6 +444,15 @@ func (s *SwapService) SwapIn(peer string, chain string, channelId string, initia
 		return nil, ErrMinimumSwapSize(s.swapServices.policy.GetMinSwapAmountMsat())
 	}
 
+	rs, err := s.swapServices.lightning.ReceivableMsat(channelId)
+	if err != nil {
+		return nil, err
+	}
+
+	if rs <= amtSat*1000 {
+		return nil, fmt.Errorf("exceeding receivable amount_msat: %d", rs)
+	}
+
 	var bitcoinNetwork string
 	var elementsAsset string
 	if chain == l_btc_chain {
@@ -454,7 +463,7 @@ func (s *SwapService) SwapIn(peer string, chain string, channelId string, initia
 		return nil, errors.New("invalid chain")
 	}
 	swap := newSwapInSenderFSM(s.swapServices, initiator, peer)
-	err := s.lockSwap(swap.SwapId.String(), channelId, swap)
+	err = s.lockSwap(swap.SwapId.String(), channelId, swap)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/service.go
+++ b/swap/service.go
@@ -383,6 +383,15 @@ func (s *SwapService) SwapOut(peer string, chain string, channelId string, initi
 		return nil, err
 	}
 
+	sp, err := s.swapServices.lightning.SpendableMsat(channelId)
+	if err != nil {
+		return nil, err
+	}
+
+	if sp <= amtSat*1000 {
+		return nil, fmt.Errorf("exceeding spendable amount_msat: %d", sp)
+	}
+
 	swap := newSwapOutSenderFSM(s.swapServices, initiator, peer)
 	err = s.lockSwap(swap.SwapId.String(), channelId, swap)
 	if err != nil {

--- a/swap/services.go
+++ b/swap/services.go
@@ -49,6 +49,7 @@ type LightningClient interface {
 	CanSpend(amountMsat uint64) error
 	Implementation() string
 	SpendableMsat(scid string) (uint64, error)
+	ReceivableMsat(scid string) (uint64, error)
 }
 
 type TxWatcher interface {

--- a/swap/services.go
+++ b/swap/services.go
@@ -48,6 +48,7 @@ type LightningClient interface {
 	RebalancePayment(payreq string, channel string) (preimage string, err error)
 	CanSpend(amountMsat uint64) error
 	Implementation() string
+	SpendableMsat(scid string) (uint64, error)
 }
 
 type TxWatcher interface {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -254,10 +254,18 @@ type dummyLightningClient struct {
 
 	canSpendError  error
 	canSpendCalled int
+
+	spendableMsatCalled int
+	spendableMsat       uint64
 }
 
 func (d *dummyLightningClient) Implementation() string {
 	return "dummy"
+}
+
+func (d *dummyLightningClient) SpendableMsat(scid string) (uint64, error) {
+	d.spendableMsatCalled++
+	return d.spendableMsat, nil
 }
 
 func (d *dummyLightningClient) CanSpend(amtMsat uint64) error {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -324,10 +324,6 @@ func (d *dummyLightningClient) DecodePayreq(payreq string) (string, uint64, int6
 	return "foo", 100000 * 1000, 10, nil
 }
 
-func (d *dummyLightningClient) CheckChannel(channelId string, amount uint64) error {
-	return nil
-}
-
 func (d *dummyLightningClient) PayInvoice(payreq string) (preImage string, err error) {
 	if d.failpayment {
 		return "", errors.New("payment failed")

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -3,6 +3,7 @@ package swap
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/elementsproject/peerswap/lightning"
@@ -255,8 +256,8 @@ type dummyLightningClient struct {
 	canSpendError  error
 	canSpendCalled int
 
-	spendableMsatCalled int
-	spendableMsat       uint64
+	spendableMsatCalled  int
+	receivableMsatCalled int
 }
 
 func (d *dummyLightningClient) Implementation() string {
@@ -265,7 +266,12 @@ func (d *dummyLightningClient) Implementation() string {
 
 func (d *dummyLightningClient) SpendableMsat(scid string) (uint64, error) {
 	d.spendableMsatCalled++
-	return d.spendableMsat, nil
+	return math.MaxUint64, nil
+}
+
+func (d *dummyLightningClient) ReceivableMsat(scid string) (uint64, error) {
+	d.receivableMsatCalled++
+	return math.MaxUint64, nil
 }
 
 func (d *dummyLightningClient) CanSpend(amtMsat uint64) error {

--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -939,3 +939,72 @@ func Test_ClnLnd_Bitcoin_SwapOut(t *testing.T) {
 	})
 
 }
+
+func Test_ClnCln_ExcessiveAmount(t *testing.T) {
+	IsIntegrationTest(t)
+
+	t.Parallel()
+	require := require.New(t)
+
+	bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
+	defer func() {
+		if t.Failed() {
+			filter := os.Getenv("PEERSWAP_TEST_FILTER")
+			pprintFail(
+				tailableProcess{
+					p:     bitcoind.DaemonProcess,
+					lines: defaultLines,
+				},
+				tailableProcess{
+					p:      lightningds[0].DaemonProcess,
+					filter: filter,
+					lines:  defaultLines,
+				},
+				tailableProcess{
+					p:     lightningds[1].DaemonProcess,
+					lines: defaultLines,
+				},
+			)
+		}
+	}()
+
+	var channelBalances []uint64
+	var walletBalances []uint64
+	for _, lightningd := range lightningds {
+		b, err := lightningd.GetBtcBalanceSat()
+		require.NoError(err)
+		walletBalances = append(walletBalances, b)
+
+		b, err = lightningd.GetChannelBalanceSat(scid)
+		require.NoError(err)
+		channelBalances = append(channelBalances, b)
+	}
+
+	params := &testParams{
+		swapAmt:          2 * channelBalances[0],
+		scid:             scid,
+		origTakerWallet:  walletBalances[0],
+		origMakerWallet:  walletBalances[1],
+		origTakerBalance: channelBalances[0],
+		origMakerBalance: channelBalances[1],
+		takerNode:        lightningds[0],
+		makerNode:        lightningds[1],
+		takerPeerswap:    lightningds[0].DaemonProcess,
+		makerPeerswap:    lightningds[1].DaemonProcess,
+		chainRpc:         bitcoind.RpcProxy,
+		chaind:           bitcoind,
+		confirms:         BitcoinConfirms,
+		csv:              BitcoinCsv,
+		swapType:         swap.SWAPTYPE_OUT,
+	}
+	asset := "btc"
+
+	// Swap out should fail as the swap_amt is to high.
+	var response map[string]interface{}
+	err := lightningds[0].Rpc.Request(&clightning.SwapOut{SatAmt: params.swapAmt, ShortChannelId: params.scid, Asset: asset}, &response)
+	assert.Error(t, err)
+
+	// Swap in should fail as the swap_amt is to high.
+	err = lightningds[1].Rpc.Request(&clightning.SwapIn{SatAmt: params.swapAmt, ShortChannelId: params.scid, Asset: asset}, &response)
+	assert.Error(t, err)
+}

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -72,7 +72,7 @@ func Test_Wumbo(t *testing.T) {
 			largeChannelsEnabled: false,
 			swapAmtSat:           maxPaymentSize + 1,
 			swapType:             swap.SWAPTYPE_IN,
-			expectedError:        fmt.Errorf("-1:swap canceled, reason: from the CLN peer: swap amount is 4294968000: need to enable option '--large-channels' to swap amounts larger than 2^32 msat"),
+			expectedError:        fmt.Errorf("-1:swap amount is 4294968000: need to enable option '--large-channels' to swap amounts larger than 2^32 msat"),
 		},
 		{
 			description:          "in_lc_max",


### PR DESCRIPTION
We add an additional check that we can spend/receive the swap amount over the desired channel before initiating a swap.