### PR TITLE
Bump nixpkgs

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -1,11 +1,11 @@
 let
-# Pinning to revision c65c2f09e5bb54cbbbc4aa72030d62e138d8f0cf 
-# - cln v23.02.2
-# - lnd v0.16.2-beta
-# - bitcoin v24.0.1
-# - elements v22.1.0
+# Pinning to revision d5954b58c980c4fb1d87a938ee65f2013104df26
+# - cln v23.08
+# - lnd v0.16.3-beta
+# - bitcoin v25.0
+# - elements v22.1.1
 
-rev = "c65c2f09e5bb54cbbbc4aa72030d62e138d8f0cf";
+rev = "d5954b58c980c4fb1d87a938ee65f2013104df26";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
 

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -412,11 +412,7 @@ func (n *LndNode) IsChannelActive(scid string) (bool, error) {
 	for _, ch := range r.Channels {
 		chScid := ScidFromLndChanId(ch.ChanId)
 		if chScid == scid {
-			chinfo, err := n.Rpc.GetChanInfo(context.Background(), &lnrpc.ChanInfoRequest{ChanId: ch.ChanId})
-			if err != nil {
-				return false, nil
-			}
-			return ch.Active && chinfo.Node1Policy != nil && chinfo.Node2Policy != nil, nil
+			return ch.Active, nil
 		}
 	}
 


### PR DESCRIPTION
* Updates the daemons to:
cln v23.08
lnd v0.16.3-beta
bitcoin v25.0
elements v22.1.1

* Do not check for routing policy when checking for channel activation in test
    * Even if I remove the check, the ci will still go through.  
    I could not figure out why we were checking at this time in the original process, but please confirm that there is no problem.