### PR TITLE
Wait for swap in State_SwapInSender_AwaitAgreement if it exists

### DIFF
--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -101,7 +101,7 @@ func Test_OnlyOneActiveSwapPerChannelCln(t *testing.T) {
 	t.Logf("GOT: %v", response)
 
 	assert.EqualValues(t, N_SWAPS-1, nErr, "expected nswaps-1=%d errors, got: %d", N_SWAPS-1, nErr)
-	assert.EqualValues(t, len(response.Swaps), 1, "expected only 1 active swap, got: %d", len(response.Swaps))
+	assert.EqualValues(t, 1, len(response.Swaps), "expected only 1 active swap, got: %d", len(response.Swaps))
 }
 
 func Test_ClnCln_Bitcoin_SwapIn(t *testing.T) {

--- a/test/bitcoin_lnd_test.go
+++ b/test/bitcoin_lnd_test.go
@@ -112,7 +112,7 @@ func Test_OnlyOneActiveSwapPerChannelLnd(t *testing.T) {
 	res, err := peerswapds[1].PeerswapClient.ListActiveSwaps(ctx, &peerswaprpc.ListSwapsRequest{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, N_SWAPS-1, nErr, "expected nswaps-1=%d errors, got: %d", N_SWAPS-1, nErr)
-	assert.EqualValues(t, len(res.Swaps), 1, "expected only 1 active swap, got: %d - %v", len(res.Swaps), res)
+	assert.EqualValues(t, 1, len(res.Swaps), "expected only 1 active swap, got: %d - %v", len(res.Swaps), res)
 }
 
 func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {

--- a/test/bitcoin_lnd_test.go
+++ b/test/bitcoin_lnd_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/elementsproject/peerswap/peerswaprpc"
 	"github.com/elementsproject/peerswap/swap"
@@ -109,10 +110,21 @@ func Test_OnlyOneActiveSwapPerChannelLnd(t *testing.T) {
 	}
 	wg.Wait()
 
-	res, err := peerswapds[1].PeerswapClient.ListActiveSwaps(ctx, &peerswaprpc.ListSwapsRequest{})
-	assert.NoError(t, err)
 	assert.EqualValues(t, N_SWAPS-1, nErr, "expected nswaps-1=%d errors, got: %d", N_SWAPS-1, nErr)
-	assert.EqualValues(t, 1, len(res.Swaps), "expected only 1 active swap, got: %d - %v", len(res.Swaps), res)
+	err = testframework.WaitForWithErr(func() (bool, error) {
+		res, err := peerswapds[1].PeerswapClient.ListActiveSwaps(ctx, &peerswaprpc.ListSwapsRequest{})
+		if err != nil {
+			return false, err
+		}
+		for _, r := range res.Swaps {
+			if r.State == string(swap.State_SwapInSender_AwaitAgreement) {
+				return false, nil
+			}
+		}
+		assert.EqualValues(t, 1, len(res.Swaps), "expected only 1 active swap, got: %d - %v", len(res.Swaps), res)
+		return true, nil
+	}, 2*time.Second)
+	assert.NoError(t, err)
 }
 
 func Test_LndLnd_Bitcoin_SwapIn(t *testing.T) {


### PR DESCRIPTION
Fixes flake https://github.com/ElementsProject/peerswap/actions/runs/6104788193.
If there is a swap in the State_SwapInSender_AwaitAgreement state with cancel message, it is likely to complete after a certain period of time, so wait.