### PR TITLE
test: the amount of the fee invoice is taken into account when testing

### DIFF
--- a/test/testcases.go
+++ b/test/testcases.go
@@ -47,7 +47,7 @@ func coopClaimTest(t *testing.T, params *testParams) {
 	feeInvoiceAmt, err := params.makerNode.GetFeeInvoiceAmtSat()
 	require.NoError(err)
 
-	moveAmt := (params.origTakerBalance - params.swapAmt) + 100
+	moveAmt := (params.origTakerBalance - feeInvoiceAmt - params.swapAmt) + 1
 	inv, err := params.makerNode.AddInvoice(moveAmt, "shift balance", "")
 	require.NoError(err)
 
@@ -59,8 +59,7 @@ func coopClaimTest(t *testing.T, params *testParams) {
 	err = testframework.WaitFor(func() bool {
 		setTakerFunds, err = params.takerNode.GetChannelBalanceSat(params.scid)
 		require.NoError(err)
-		return params.origTakerBalance-moveAmt-10-feeInvoiceAmt < setTakerFunds &&
-			setTakerFunds < params.origTakerBalance-moveAmt+10-feeInvoiceAmt
+		return setTakerFunds == params.swapAmt-1
 	}, testframework.TIMEOUT)
 	require.NoError(err)
 

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/elementsproject/glightning/glightning"
@@ -503,4 +504,18 @@ func (n *CLightningNode) GetMemoFromPayreq(bolt11 string) (string, error) {
 	}
 
 	return r.Description, nil
+}
+
+func (n *CLightningNode) GetFeeInvoiceAmtSat() (sat uint64, err error) {
+	var feeInvoiceAmt uint64
+	r, err := n.Rpc.ListInvoices()
+	if err != nil {
+		return 0, err
+	}
+	for _, i := range r {
+		if strings.Contains(i.Description, "fee") {
+			feeInvoiceAmt += i.AmountMilliSatoshi.MSat() / 1000
+		}
+	}
+	return feeInvoiceAmt, nil
 }

--- a/testframework/lightning.go
+++ b/testframework/lightning.go
@@ -30,6 +30,7 @@ type LightningNode interface {
 	// invoices.
 	GetLatestInvoice() (payreq string, err error)
 	GetMemoFromPayreq(payreq string) (memo string, err error)
+	GetFeeInvoiceAmtSat() (sat uint64, err error)
 
 	Run(waitForReady, swaitForBitcoinSynced bool) error
 	Stop() error


### PR DESCRIPTION
This is a fix for a testing bug and the resulting reduction in testing time.
I expect to shorten the test time by approximately 7 minutes.

Claim coop testing of swap out time is dominating.  
The reason seems to be that the channel taker balance check is stuck in an infinite loop until time out.

In the case of swap out, the amount of the fee invoice needs to be taken into account.