### PR TITLE
Fix invoice description flake

### DIFF
--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/elementsproject/glightning/glightning"
@@ -507,13 +506,14 @@ func (n *CLightningNode) GetMemoFromPayreq(bolt11 string) (string, error) {
 }
 
 func (n *CLightningNode) GetFeeInvoiceAmtSat() (sat uint64, err error) {
+	rx := regexp.MustCompile(`^peerswap .* fee .*`)
 	var feeInvoiceAmt uint64
 	r, err := n.Rpc.ListInvoices()
 	if err != nil {
 		return 0, err
 	}
 	for _, i := range r {
-		if strings.Contains(i.Description, "fee") {
+		if rx.MatchString(i.Description) {
 			feeInvoiceAmt += i.AmountMilliSatoshi.MSat() / 1000
 		}
 	}

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -515,6 +515,7 @@ func ScidFromLndChanId(id uint64) string {
 }
 
 func (n *LndNode) GetFeeInvoiceAmtSat() (sat uint64, err error) {
+	rx := regexp.MustCompile(`^peerswap .* fee .*`)
 	var feeInvoiceAmt uint64
 	r, err := n.Rpc.ListInvoices(context.Background(), &lnrpc.ListInvoiceRequest{})
 	if err != nil {
@@ -522,7 +523,7 @@ func (n *LndNode) GetFeeInvoiceAmtSat() (sat uint64, err error) {
 	}
 
 	for _, i := range r.Invoices {
-		if strings.Contains(i.GetMemo(), "fee") {
+		if rx.MatchString(i.GetMemo()) {
 			feeInvoiceAmt += uint64(i.GetValue())
 		}
 	}


### PR DESCRIPTION
There has been a weird flake where Lnd reported: 
```rpc error: code = Unknown desc = amount 18446744073534561616 pBTC not expressible in msat```

Here is what happened:

- The recently introduced testframework method `GetFeeInvoiceAmtSat()` 56ad78415d5b5150190a5b7d56164727546b4a13 accumulates the amounts of invoices with a description that contains the string "fee".
- The description always contains the `swapid` which is 32 bytes random and hex encoded and can therefore sometimes contain the sub-string "fee".
- When this happens `GetFeeInvoiceAmtSat()` adds the `claim-invoice` amount to the total amount.
This leads to an _underflowed_ `moveAmt` which causes the invoice amount of `18446744073534561616`.

This PR changes the accumulation criterion to a regex match of the form "peerswap [ABC] fee [XYZ]" to avoid collisions with the `swapid`.