### PR TITLE
Sanity check max htlc amount msat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,8 @@ test-bitcoin-lnd: test-bins
 	'Test_LndLnd_Bitcoin_SwapOut|'\
 	'Test_LndLnd_Bitcoin_SwapIn|'\
 	'Test_LndCln_Bitcoin_SwapOut|'\
-	'Test_LndCln_Bitcoin_SwapIn)'\
+	'Test_LndCln_Bitcoin_SwapIn|'\
+	'Test_LndLnd_ExcessiveAmount)'\
 	 ./test
 	${INTEGRATION_TEST_ENV} go test $(INTEGRATION_TEST_OPTS) ./lnd
 .PHONY: test-bitcoin-lnd

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -579,6 +579,15 @@ func (r *PayFeeInvoiceAction) Execute(services *SwapServices, swap *SwapData) Ev
 		return swap.HandleError(err)
 	}
 
+	sp, err := ll.SpendableMsat(swap.SwapOutRequest.Scid)
+	if err != nil {
+		return swap.HandleError(err)
+	}
+
+	if sp <= swap.SwapOutRequest.Amount*1000 {
+		return swap.HandleError(err)
+	}
+
 	swap.OpeningTxFee = msatAmt / 1000
 
 	expectedFee, err := wallet.GetFlatSwapOutFee()

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/elementsproject/glightning/glightning"
+	"github.com/elementsproject/peerswap/lightning"
 )
 
 type CLightningNode struct {
@@ -518,4 +519,39 @@ func (n *CLightningNode) GetFeeInvoiceAmtSat() (sat uint64, err error) {
 		}
 	}
 	return feeInvoiceAmt, nil
+}
+
+type SetChannel struct {
+	Id                       string `json:"id"`
+	HtlcMaximumMilliSatoshis string `json:"htlcmax,omitempty"`
+}
+
+type ChannelInfo struct {
+	PeerID                    string            `json:"peer_id"`
+	ChannelID                 string            `json:"channel_id"`
+	ShortChannelID            string            `json:"short_channel_id"`
+	FeeBaseMsat               glightning.Amount `json:"fee_base_msat"`
+	FeeProportionalMillionths glightning.Amount `json:"fee_proportional_millionths"`
+	MinimumHtlcOutMsat        glightning.Amount `json:"minimum_htlc_out_msat"`
+	MaximumHtlcOutMsat        glightning.Amount `json:"maximum_htlc_out_msat"`
+}
+
+type SetChannelResponse struct {
+	Channels []ChannelInfo `json:"channels"`
+}
+
+func (r *SetChannel) Name() string {
+	return "setchannel"
+}
+
+func (n *CLightningNode) SetHtlcMaximumMilliSatoshis(scid string, maxHtlcMsat uint64) (msat uint64, err error) {
+	var res SetChannelResponse
+	err = n.Rpc.Request(&SetChannel{
+		Id:                       lightning.Scid(scid).ClnStyle(),
+		HtlcMaximumMilliSatoshis: fmt.Sprint(maxHtlcMsat),
+	}, &res)
+	if err != nil {
+		return 0, err
+	}
+	return maxHtlcMsat, err
 }

--- a/testframework/lightning.go
+++ b/testframework/lightning.go
@@ -33,5 +33,6 @@ type LightningNode interface {
 	GetFeeInvoiceAmtSat() (sat uint64, err error)
 
 	Run(waitForReady, swaitForBitcoinSynced bool) error
+	SetHtlcMaximumMilliSatoshis(scid string, maxHtlcMsat uint64) (msat uint64, err error)
 	Stop() error
 }


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/peerswap/issues/81

* check the channel's max htlc limit
Added logic to check the maximum htlc limit set per node for each channel.
In cln, max htlc amt is not affect, so checks are only performed when the sender is lnd.
receivable amount depends on whether the node is a cln or a lnd, so max htlc amt is not taken into account.
Also, since the max htlc limit is not always set reliably, the check is skipped if it is not set.

* add sanity check of spendable amt at `swap_out_agreement `