### PR TITLE
cln: Sanity check max htlc amount msat

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -217,21 +217,23 @@ type ListPeerChannelsResponse struct {
 }
 
 type PeerChannel struct {
-	PeerId         string            `json:"peer_id"`
-	PeerConnected  bool              `json:"peer_connected"`
-	State          string            `json:"state"`
-	ShortChannelId string            `json:"short_channel_id,omitempty"`
-	TotalMsat      glightning.Amount `json:"total_msat,omitempty"`
-	ToUsMsat       glightning.Amount `json:"to_us_msat,omitempty"`
-	ReceivableMsat glightning.Amount `json:"receivable_msat,omitempty"`
-	SpendableMsat  glightning.Amount `json:"spendable_msat,omitempty"`
+	PeerId           string            `json:"peer_id"`
+	PeerConnected    bool              `json:"peer_connected"`
+	State            string            `json:"state"`
+	ShortChannelId   string            `json:"short_channel_id,omitempty"`
+	TotalMsat        glightning.Amount `json:"total_msat,omitempty"`
+	ToUsMsat         glightning.Amount `json:"to_us_msat,omitempty"`
+	ReceivableMsat   glightning.Amount `json:"receivable_msat,omitempty"`
+	SpendableMsat    glightning.Amount `json:"spendable_msat,omitempty"`
+	TheirReserveMsat glightning.Amount `json:"their_reserve_msat,omitempty"`
+	OurReserveMsat   glightning.Amount `json:"our_reserve_msat,omitempty"`
 }
 
 func (ch *PeerChannel) GetSpendableMsat() uint64 {
 	if ch.SpendableMsat.MSat() > 0 {
 		return ch.SpendableMsat.MSat()
 	} else {
-		return ch.ToUsMsat.MSat()
+		return ch.ToUsMsat.MSat() - ch.OurReserveMsat.MSat()
 	}
 }
 
@@ -239,7 +241,7 @@ func (ch *PeerChannel) GetReceivableMsat() uint64 {
 	if ch.ReceivableMsat.MSat() > 0 {
 		return ch.ReceivableMsat.MSat()
 	} else {
-		return ch.TotalMsat.MSat() - ch.ToUsMsat.MSat()
+		return ch.TotalMsat.MSat() - ch.ToUsMsat.MSat() - ch.TheirReserveMsat.MSat()
 	}
 }
 

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -217,6 +217,7 @@ type ListPeerChannelsResponse struct {
 }
 
 type PeerChannel struct {
+	PeerId         string            `json:"peer_id"`
 	PeerConnected  bool              `json:"peer_connected"`
 	State          string            `json:"state"`
 	ShortChannelId string            `json:"short_channel_id,omitempty"`
@@ -224,6 +225,36 @@ type PeerChannel struct {
 	ToUsMsat       glightning.Amount `json:"to_us_msat,omitempty"`
 	ReceivableMsat glightning.Amount `json:"receivable_msat,omitempty"`
 	SpendableMsat  glightning.Amount `json:"spendable_msat,omitempty"`
+}
+
+func (ch *PeerChannel) GetSpendableMsat() uint64 {
+	if ch.SpendableMsat.MSat() > 0 {
+		return ch.SpendableMsat.MSat()
+	} else {
+		return ch.ToUsMsat.MSat()
+	}
+}
+
+func (ch *PeerChannel) GetReceivableMsat() uint64 {
+	if ch.ReceivableMsat.MSat() > 0 {
+		return ch.ReceivableMsat.MSat()
+	} else {
+		return ch.TotalMsat.MSat() - ch.ToUsMsat.MSat()
+	}
+}
+
+func (cl *ClightningClient) getMaxHtlcAmtMsat(scid, nodeId string) (uint64, error) {
+	var htlcMaximumMilliSatoshis uint64
+	chgs, err := cl.glightning.GetChannel(scid)
+	if err != nil {
+		return htlcMaximumMilliSatoshis, nil
+	}
+	for _, c := range chgs {
+		if c.Source == nodeId {
+			htlcMaximumMilliSatoshis = c.HtlcMaximumMilliSatoshis.MSat()
+		}
+	}
+	return htlcMaximumMilliSatoshis, nil
 }
 
 // SpendableMsat returns an estimate of the total we could send through the
@@ -240,14 +271,26 @@ func (cl *ClightningClient) SpendableMsat(scid string) (uint64, error) {
 			if err = cl.checkChannel(ch); err != nil {
 				return 0, err
 			}
-			if ch.SpendableMsat.MSat() > 0 {
-				return ch.SpendableMsat.MSat(), nil
-			} else {
-				return ch.ToUsMsat.MSat(), nil
+			maxHtlcAmtMsat, err := cl.getMaxHtlcAmtMsat(scid, cl.nodeId)
+			if err != nil {
+				return 0, err
 			}
+			// since the max htlc limit is not always set reliably,
+			// the check is skipped if it is not set.
+			if maxHtlcAmtMsat == 0 {
+				return ch.GetSpendableMsat(), nil
+			}
+			return min(maxHtlcAmtMsat, ch.GetSpendableMsat()), nil
 		}
 	}
 	return 0, fmt.Errorf("could not find a channel with scid: %s", scid)
+}
+
+func min(x, y uint64) uint64 {
+	if x < y {
+		return x
+	}
+	return y
 }
 
 // ReceivableMsat returns an estimate of the total we could receive through the
@@ -264,11 +307,16 @@ func (cl *ClightningClient) ReceivableMsat(scid string) (uint64, error) {
 			if err = cl.checkChannel(ch); err != nil {
 				return 0, err
 			}
-			if ch.ReceivableMsat.MSat() > 0 {
-				return ch.ReceivableMsat.MSat(), nil
-			} else {
-				return ch.TotalMsat.MSat() - ch.ToUsMsat.MSat(), nil
+			maxHtlcAmtMsat, err := cl.getMaxHtlcAmtMsat(scid, ch.PeerId)
+			if err != nil {
+				return 0, err
 			}
+			// since the max htlc limit is not always set reliably,
+			// the check is skipped if it is not set.
+			if maxHtlcAmtMsat == 0 {
+				return ch.GetReceivableMsat(), nil
+			}
+			return min(maxHtlcAmtMsat, ch.GetReceivableMsat()), nil
 		}
 	}
 	return 0, fmt.Errorf("could not find a channel with scid: %s", scid)

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -126,7 +126,8 @@ func (l *Client) SpendableMsat(scid string) (uint64, error) {
 			if err != nil {
 				return 0, err
 			}
-			spendable := uint64(ch.LocalBalance * 1000)
+			spendable := (uint64(ch.GetLocalBalance()) -
+				ch.GetLocalConstraints().GetChanReserveSat()*1000)
 			// since the max htlc limit is not always set reliably,
 			// the check is skipped if it is not set.
 			if maxHtlcAmtMsat == 0 {
@@ -162,7 +163,8 @@ func (l *Client) ReceivableMsat(scid string) (uint64, error) {
 			if err != nil {
 				return 0, err
 			}
-			receivable := uint64(ch.RemoteBalance * 1000)
+			receivable := (uint64(ch.GetRemoteBalance()) -
+				ch.GetRemoteConstraints().GetChanReserveSat()*1000)
 			// since the max htlc limit is not always set reliably,
 			// the check is skipped if it is not set.
 			if maxHtlcAmtMsat == 0 {

--- a/test/bitcoin_lnd_test.go
+++ b/test/bitcoin_lnd_test.go
@@ -1103,7 +1103,7 @@ func Test_LndCln_Bitcoin_SwapOut(t *testing.T) {
 func Test_LndLnd_ExcessiveAmount(t *testing.T) {
 	IsIntegrationTest(t)
 	t.Parallel()
-	t.Run("exceed_maxhtlc", func(t *testing.T) {
+	t.Run("swapout", func(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
@@ -1178,6 +1178,85 @@ func Test_LndLnd_ExcessiveAmount(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		_, err = peerswapds[0].PeerswapClient.SwapOut(ctx, &peerswaprpc.SwapOutRequest{
+			ChannelId:  lcid,
+			SwapAmount: params.swapAmt,
+			Asset:      asset,
+		})
+		assert.Error(t, err)
+	})
+	t.Run("swapin", func(t *testing.T) {
+		t.Parallel()
+		require := require.New(t)
+
+		bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, uint64(math.Pow10(9)))
+		defer func() {
+			if t.Failed() {
+				pprintFail(
+					tailableProcess{
+						p:     bitcoind.DaemonProcess,
+						lines: defaultLines,
+					},
+					tailableProcess{
+						p:     lightningds[0].DaemonProcess,
+						lines: defaultLines,
+					},
+					tailableProcess{
+						p:     lightningds[1].DaemonProcess,
+						lines: defaultLines,
+					},
+					tailableProcess{
+						p:     peerswapds[0].DaemonProcess,
+						lines: defaultLines,
+					},
+					tailableProcess{
+						p:     peerswapds[1].DaemonProcess,
+						lines: defaultLines,
+					},
+				)
+			}
+		}()
+
+		var channelBalances []uint64
+		var walletBalances []uint64
+		for _, lightningd := range lightningds {
+			b, err := lightningd.GetBtcBalanceSat()
+			require.NoError(err)
+			walletBalances = append(walletBalances, b)
+
+			b, err = lightningd.GetChannelBalanceSat(scid)
+			require.NoError(err)
+			channelBalances = append(channelBalances, b)
+		}
+
+		lcid, err := lightningds[0].ChanIdFromScid(scid)
+		if err != nil {
+			t.Fatalf("lightingds[0].ChanIdFromScid() %v", err)
+		}
+
+		params := &testParams{
+			swapAmt:          channelBalances[0] / 2,
+			scid:             scid,
+			origTakerWallet:  walletBalances[0],
+			origMakerWallet:  walletBalances[1],
+			origTakerBalance: channelBalances[0],
+			origMakerBalance: channelBalances[1],
+			takerNode:        lightningds[0],
+			makerNode:        lightningds[1],
+			takerPeerswap:    peerswapds[0].DaemonProcess,
+			makerPeerswap:    peerswapds[1].DaemonProcess,
+			chainRpc:         bitcoind.RpcProxy,
+			chaind:           bitcoind,
+			confirms:         BitcoinConfirms,
+			swapType:         swap.SWAPTYPE_IN,
+		}
+		asset := "btc"
+		_, err = lightningds[0].SetHtlcMaximumMilliSatoshis(scid, channelBalances[0]*1000/2-1)
+		assert.NoError(t, err)
+		// Swap out should fail as the swap_amt is to high.
+		// Do swap.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err = peerswapds[1].PeerswapClient.SwapIn(ctx, &peerswaprpc.SwapInRequest{
 			ChannelId:  lcid,
 			SwapAmount: params.swapAmt,
 			Asset:      asset,


### PR DESCRIPTION
For https://github.com/ElementsProject/peerswap/pull/246#issuecomment-1739743519
Added logic to check the maximum htlc limit for cln set per node for each channel.
Additionally checking maxhtlc would be more strict than CLN's own limitations.

Also, to ensure that the receivable amout is also taken into account.