### PR TITLE
swap: cancel swap on recovery

### DIFF
--- a/swap/swap_out_sender.go
+++ b/swap/swap_out_sender.go
@@ -55,6 +55,7 @@ func getSwapOutSenderStates() States {
 				Event_OnTimeout:            State_SendCancel,
 				Event_OnFeeInvoiceReceived: State_SwapOutSender_PayFeeInvoice,
 				Event_OnInvalid_Message:    State_SendCancel,
+				Event_ActionFailed:         State_SwapCanceled,
 			},
 			FailOnrecover: true,
 		},


### PR DESCRIPTION
Fixes [discord support bug report](https://discord.com/channels/905126649224388629/905127434779766785/1154271226756349952).

Cancel swap on recovery during State_SwapOutSender_AwaitAgreement.
Previously, when recovery on `State_SwapOutSender_AwaitAgreement` occurred, it would hang.

The receiver side is canceled when recovery occurs at `State_SwapOutReceiver_CreateSwap`,
so this change does not affect the receiver side.