### PR TITLE
probe payment as sanity check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ test-bitcoin-cln: test-bins
 	'Test_ClnCln_Bitcoin_SwapIn|'\
 	'Test_ClnLnd_Bitcoin_SwapOut|'\
 	'Test_ClnLnd_Bitcoin_SwapIn|'\
-	'Test_ClnCln_ExcessiveAmount)'\
+	'Test_ClnCln_ExcessiveAmount|'\
+	'Test_ClnCln_StuckChannels)'\
 	 ./test
 .PHONY: test-bitoin-cln
 

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -650,7 +650,17 @@ func (cl *ClightningClient) ProbePayment(scid string, amountMsat uint64) (bool, 
 	}
 	paymentHash := preimage.Hash().String()
 	_, err = cl.glightning.SendPay(
-		route,
+		[]glightning.RouteHop{
+			{
+				Id:             channel.PeerId,
+				ShortChannelId: channel.ShortChannelId,
+				AmountMsat:     glightning.AmountFromMSat(amountMsat),
+				// The total expected CLTV.
+				// The default GetRoute value of 9 is set here.
+				Delay:     9,
+				Direction: 0,
+			},
+		},
 		paymentHash,
 		"",
 		amountMsat,

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -640,10 +640,6 @@ func (cl *ClightningClient) ProbePayment(scid string, amountMsat uint64) (bool, 
 		}
 	}
 
-	route, err := cl.glightning.GetRoute(channel.PeerId, amountMsat, 1, 0, cl.nodeId, 0, nil, 1)
-	if err != nil {
-		return false, "", fmt.Errorf("GetRoute() %w", err)
-	}
 	preimage, err := lightning.GetPreimage()
 	if err != nil {
 		return false, "", fmt.Errorf("GetPreimage() %w", err)
@@ -677,8 +673,8 @@ func (cl *ClightningClient) ProbePayment(scid string, amountMsat uint64) (bool, 
 		if !ok {
 			return false, "", fmt.Errorf("WaitSendPay() %w", err)
 		}
-		faiCodeWireIncorrectOrUnknownPaymentDetails := 203
-		if pe.RpcError.Code != faiCodeWireIncorrectOrUnknownPaymentDetails {
+		failCodeWireIncorrectOrUnknownPaymentDetails := 203
+		if pe.RpcError.Code != failCodeWireIncorrectOrUnknownPaymentDetails {
 			log.Debugf("send pay would be failed. reason:%w", err)
 			return false, pe.Error(), nil
 		}

--- a/lnd/paymentwatcher_test.go
+++ b/lnd/paymentwatcher_test.go
@@ -262,7 +262,7 @@ func paymentwatcherNodeSetup(t *testing.T, dir string) (
 		return nil, nil, nil, nil, fmt.Errorf("Could not create lnd client connection: %v", err)
 	}
 
-	_, err = payer.OpenChannel(payee, uint64(math.Pow10(7)), true, true, true)
+	_, err = payer.OpenChannel(payee, uint64(math.Pow10(7)), 0, true, true, true)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("Could not open channel: %v", err)
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -78,10 +78,7 @@ type Policy struct {
 	// MinSwapAmountMsat is the minimum swap amount in msat that is needed to
 	// perform a swap. Below this amount it might be uneconomical to do a swap
 	// due to the on-chain costs.
-	// TODO: This can not be set in the policy by now but this is the place
-	// where this value belongs. Eventually we might want to make this value
-	// editable as a policy setting.
-	MinSwapAmountMsat uint64 `json:"min_swap_amount_msat"`
+	MinSwapAmountMsat uint64 `json:"min_swap_amount_msat" long:"min_swap_amount_msat" description:"The minimum amount in msat that is needed to perform a swap."`
 
 	// AllowNewSwaps can be used to disallow any new swaps. This can be useful
 	// when we want to upgrade the node and do not want to allow for any new

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -578,14 +578,12 @@ func (r *PayFeeInvoiceAction) Execute(services *SwapServices, swap *SwapData) Ev
 	if err != nil {
 		return swap.HandleError(err)
 	}
-
-	sp, err := ll.SpendableMsat(swap.SwapOutRequest.Scid)
+	success, failureReason, err := ll.ProbePayment(swap.SwapOutRequest.Scid, swap.SwapOutRequest.Amount*1000)
 	if err != nil {
 		return swap.HandleError(err)
 	}
-
-	if sp <= swap.SwapOutRequest.Amount*1000 {
-		return swap.HandleError(err)
+	if !success {
+		return swap.HandleError(fmt.Errorf("the prepayment probe was unsuccessful: %s", failureReason))
 	}
 
 	swap.OpeningTxFee = msatAmt / 1000

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -578,6 +578,14 @@ func (r *PayFeeInvoiceAction) Execute(services *SwapServices, swap *SwapData) Ev
 	if err != nil {
 		return swap.HandleError(err)
 	}
+	sp, err := ll.SpendableMsat(swap.SwapOutRequest.Scid)
+	if err != nil {
+		return swap.HandleError(err)
+	}
+
+	if sp <= swap.SwapOutRequest.Amount*1000 {
+		return swap.HandleError(err)
+	}
 	success, failureReason, err := ll.ProbePayment(swap.SwapOutRequest.Scid, swap.SwapOutRequest.Amount*1000)
 	if err != nil {
 		return swap.HandleError(err)

--- a/swap/service.go
+++ b/swap/service.go
@@ -383,13 +383,12 @@ func (s *SwapService) SwapOut(peer string, chain string, channelId string, initi
 		return nil, err
 	}
 
-	sp, err := s.swapServices.lightning.SpendableMsat(channelId)
+	success, failureReason, err := s.swapServices.lightning.ProbePayment(channelId, amtSat*1000)
 	if err != nil {
 		return nil, err
 	}
-
-	if sp <= amtSat*1000 {
-		return nil, fmt.Errorf("exceeding spendable amount_msat: %d", sp)
+	if !success {
+		return nil, fmt.Errorf("the prepayment probe was unsuccessful: %s", failureReason)
 	}
 
 	swap := newSwapOutSenderFSM(s.swapServices, initiator, peer)
@@ -507,7 +506,7 @@ func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, mes
 		return err
 	}
 
-	sp, err := s.swapServices.lightning.SpendableMsat(message.Scid)
+	success, failureReason, err := s.swapServices.lightning.ProbePayment(message.Scid, message.Amount*1000)
 	if err != nil {
 		msg := fmt.Sprintf("from the %s peer: %s", s.swapServices.lightning.Implementation(), err.Error())
 		// We want to tell our peer why we can not do this swap.
@@ -518,14 +517,11 @@ func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, mes
 		s.swapServices.messenger.SendMessage(peerId, msgBytes, msgType)
 		return err
 	}
-
-	if sp <= message.Amount*1000 {
-		err = fmt.Errorf("exceeding spendable amount_msat: %d", sp)
-		msg := fmt.Sprintf("from the %s peer: %s", s.swapServices.lightning.Implementation(), err.Error())
+	if !success {
 		// We want to tell our peer why we can not do this swap.
 		msgBytes, msgType, err := MarshalPeerswapMessage(&CancelMessage{
 			SwapId:  swapId,
-			Message: msg,
+			Message: "The prepayment probe was unsuccessful." + failureReason,
 		})
 		s.swapServices.messenger.SendMessage(peerId, msgBytes, msgType)
 		return err

--- a/swap/services.go
+++ b/swap/services.go
@@ -49,6 +49,7 @@ type LightningClient interface {
 	RebalancePayment(payreq string, channel string) (preimage string, err error)
 	CanSpend(amountMsat uint64) error
 	Implementation() string
+	SpendableMsat(scid string) (uint64, error)
 	ReceivableMsat(scid string) (uint64, error)
 	ProbePayment(scid string, amountMsat uint64) (bool, string, error)
 }

--- a/swap/services.go
+++ b/swap/services.go
@@ -49,8 +49,8 @@ type LightningClient interface {
 	RebalancePayment(payreq string, channel string) (preimage string, err error)
 	CanSpend(amountMsat uint64) error
 	Implementation() string
-	SpendableMsat(scid string) (uint64, error)
 	ReceivableMsat(scid string) (uint64, error)
+	ProbePayment(scid string, amountMsat uint64) (bool, string, error)
 }
 
 type TxWatcher interface {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -352,6 +352,10 @@ func (d *dummyLightningClient) PayInvoiceViaChannel(payreq, scid string) (preima
 	return pi.String(), nil
 }
 
+func (d *dummyLightningClient) ProbePayment(scid string, amountMsat uint64) (bool, string, error) {
+	return true, "", nil
+}
+
 type dummyPolicy struct {
 	isPeerSuspiciousReturn bool
 	isPeerSuspiciousParam  string

--- a/test/setup.go
+++ b/test/setup.go
@@ -31,14 +31,14 @@ const (
 )
 
 func clnclnSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
-	return clnclnSetupWithConfig(t, fundAmt, []string{
+	return clnclnSetupWithConfig(t, fundAmt, 0, []string{
 		"--dev-bitcoind-poll=1",
 		"--dev-fast-gossip",
 		"--large-channels",
 	})
 }
 
-func clnclnSetupWithConfig(t *testing.T, fundAmt uint64, clnConf []string) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
+func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64, clnConf []string) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
@@ -65,7 +65,8 @@ func clnclnSetupWithConfig(t *testing.T, fundAmt uint64, clnConf []string) (*tes
 		if err != nil {
 			t.Fatal("could not create dir", err)
 		}
-		err = os.WriteFile(filepath.Join(lightningd.GetDataDir(), "peerswap", "policy.conf"), []byte("accept_all_peers=1\n"), os.ModePerm)
+		err = os.WriteFile(filepath.Join(lightningd.GetDataDir(), "peerswap", "policy.conf"),
+			[]byte("accept_all_peers=1\nmin_swap_amount_msat=1\n"), os.ModePerm)
 		if err != nil {
 			t.Fatal("could not create policy file", err)
 		}
@@ -107,7 +108,7 @@ func clnclnSetupWithConfig(t *testing.T, fundAmt uint64, clnConf []string) (*tes
 	}
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, pushAmt, true, true, true)
 	if err != nil {
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
@@ -185,7 +186,7 @@ func lndlndSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*t
 	}
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, 0, true, true, true)
 	if err != nil {
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
@@ -312,7 +313,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 	}
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, 0, true, true, true)
 	if err != nil {
 		t.Fatalf("lightningds[0].OpenChannel() %v", err)
 	}
@@ -454,7 +455,7 @@ func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 	require.NoError(t, err)
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1]).
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, 0, true, true, true)
 	if err != nil {
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
@@ -575,7 +576,7 @@ func lndlndElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 	require.NoError(t, err)
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, 0, true, true, true)
 	if err != nil {
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
@@ -764,7 +765,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 	}
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, 0, true, true, true)
 	if err != nil {
 		t.Fatalf("cln.OpenChannel() %v", err)
 	}

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -108,7 +108,7 @@ func Test_Wumbo(t *testing.T) {
 			}
 
 			// Test Swap-out
-			bitcoind, lightningds, scid := clnclnSetupWithConfig(t, maxChanSize, options)
+			bitcoind, lightningds, scid := clnclnSetupWithConfig(t, maxChanSize, 0, options)
 			defer func() {
 				if t.Failed() {
 					filter := os.Getenv("PEERSWAP_TEST_FILTER")

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -299,7 +299,7 @@ func (n *CLightningNode) FundWallet(sats uint64, mineBlock bool) (string, error)
 	return addr, nil
 }
 
-func (n *CLightningNode) OpenChannel(remote LightningNode, capacity uint64, connect, confirm, waitForActiveChannel bool) (string, error) {
+func (n *CLightningNode) OpenChannel(remote LightningNode, capacity, pushAmt uint64, connect, confirm, waitForActiveChannel bool) (string, error) {
 	_, err := n.FundWallet(uint64(1.5*float64(capacity)), true)
 	if err != nil {
 		return "", fmt.Errorf("FundWallet() %w", err)
@@ -317,7 +317,8 @@ func (n *CLightningNode) OpenChannel(remote LightningNode, capacity uint64, conn
 		}
 	}
 
-	fr, err := n.Rpc.FundChannel(remote.Id(), &glightning.Sat{Value: capacity})
+	pushAmtSat := &glightning.Sat{Value: pushAmt}
+	fr, err := n.Rpc.FundChannelExt(remote.Id(), &glightning.Sat{Value: capacity}, nil, true, nil, pushAmtSat.ConvertMsat())
 	if err != nil {
 		return "", fmt.Errorf("FundChannel() %w", err)
 	}

--- a/testframework/lightning.go
+++ b/testframework/lightning.go
@@ -21,6 +21,7 @@ type LightningNode interface {
 	IsBlockHeightSynced() (bool, error)
 	IsChannelActive(scid string) (bool, error)
 	IsConnected(peer LightningNode) (bool, error)
+	HasRoute(remote, scid string) (bool, error)
 
 	AddInvoice(amtSat uint64, desc, label string) (payreq string, err error)
 	PayInvoice(payreq string) error

--- a/testframework/lightning.go
+++ b/testframework/lightning.go
@@ -16,7 +16,7 @@ type LightningNode interface {
 
 	Connect(peer LightningNode, waitForConnection bool) error
 	FundWallet(sats uint64, mineBlock bool) (addr string, err error)
-	OpenChannel(peer LightningNode, capacity uint64, connect, confirm, waitForChannelActive bool) (scid string, err error)
+	OpenChannel(peer LightningNode, capacity, pushAmt uint64, connect, confirm, waitForChannelActive bool) (scid string, err error)
 
 	IsBlockHeightSynced() (bool, error)
 	IsChannelActive(scid string) (bool, error)

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -292,7 +292,7 @@ func (n *LndNode) FundWallet(sats uint64, mineBlock bool) (string, error) {
 	return addr.Address, nil
 }
 
-func (n *LndNode) OpenChannel(peer LightningNode, capacity uint64, connect, confirm, waitForChannelActive bool) (string, error) {
+func (n *LndNode) OpenChannel(peer LightningNode, capacity, pushAmt uint64, connect, confirm, waitForChannelActive bool) (string, error) {
 	// fund wallet 10*cap
 	_, err := n.FundWallet(uint64(1.1*float64(capacity)), true)
 	if err != nil {
@@ -318,6 +318,7 @@ func (n *LndNode) OpenChannel(peer LightningNode, capacity uint64, connect, conf
 	stream, err := n.Rpc.OpenChannel(context.Background(), &lnrpc.OpenChannelRequest{
 		NodePubkey:         pk,
 		LocalFundingAmount: int64(capacity),
+		PushSat:            int64(pushAmt),
 	})
 	if err != nil {
 		return "", fmt.Errorf("OpenChannel() %w", err)

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/elementsproject/peerswap/lightning"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 func getLndConfig() map[string]string {
@@ -375,7 +377,11 @@ func (n *LndNode) OpenChannel(peer LightningNode, capacity, pushAmt uint64, conn
 					return false, fmt.Errorf("IsChannelActive() %w", err)
 				}
 			}
-			return remoteActive && localActive, nil
+			hasRoute, err := n.HasRoute(peer.Id(), scid)
+			if err != nil {
+				return false, nil
+			}
+			return remoteActive && localActive && hasRoute, nil
 		}, TIMEOUT)
 		if err != nil {
 			return "", fmt.Errorf("error waiting for active channel: %w", err)
@@ -388,6 +394,39 @@ func (n *LndNode) OpenChannel(peer LightningNode, capacity, pushAmt uint64, conn
 	}
 
 	return scid, nil
+}
+
+// HasRoute check the route is constructed
+func (n *LndNode) HasRoute(remote, scid string) (bool, error) {
+	chsRes, err := n.Rpc.ListChannels(context.Background(), &lnrpc.ListChannelsRequest{})
+	if err != nil {
+		return false, fmt.Errorf("ListChannels() %w", err)
+	}
+	var channel *lnrpc.Channel
+	for _, ch := range chsRes.GetChannels() {
+		channelShortId := lnwire.NewShortChanIDFromInt(ch.ChanId)
+		if channelShortId.String() == lightning.Scid(scid).LndStyle() {
+			channel = ch
+		}
+	}
+	if channel.GetChanId() == 0 {
+		return false, fmt.Errorf("could not find a channel with scid: %s", scid)
+	}
+	v, err := route.NewVertexFromStr(channel.GetRemotePubkey())
+	if err != nil {
+		return false, fmt.Errorf("NewVertexFromStr() %w", err)
+	}
+
+	routeres, err := n.RpcV2.BuildRoute(context.Background(), &routerrpc.BuildRouteRequest{
+		AmtMsat:        channel.GetLocalBalance() * 1000 / 2,
+		FinalCltvDelta: 9,
+		OutgoingChanId: channel.GetChanId(),
+		HopPubkeys:     [][]byte{v[:]},
+	})
+	if err != nil {
+		return false, fmt.Errorf("BuildRoute() %w", err)
+	}
+	return len(routeres.GetRoute().Hops) > 0, nil
 }
 
 func (n *LndNode) IsBlockHeightSynced() (bool, error) {


### PR DESCRIPTION
# What
I added sanity check of `ProbePayment`.
If the result of `ProbePayment` is assumed to be a payment failure, log the reason.

Also, change `MinSwapAmountMsat` to be able to set by policy to test stuck channels in test.

# Why
LN channels can [get stuck](https://github.com/lightning/bolts/issues/728) in rare.
The onchain fees were wasted because they could not be detected.
By probing payment, sanity checks can detect them.