### PR TITLE
bump nixpkgs and add --developer flag to cln test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ test-bitcoin-cln: test-bins
 	'Test_ClnCln_Bitcoin_SwapIn|'\
 	'Test_ClnLnd_Bitcoin_SwapOut|'\
 	'Test_ClnLnd_Bitcoin_SwapIn|'\
-	'Test_ClnCln_ExcessiveAmount)'\
+	'Test_ClnCln_ExcessiveAmount|'\
+	'Test_ClnCln_StuckChannels)'\
 	 ./test
 .PHONY: test-bitoin-cln
 

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,7 @@ test-bitcoin-cln: test-bins
 	'Test_ClnCln_Bitcoin_SwapIn|'\
 	'Test_ClnLnd_Bitcoin_SwapOut|'\
 	'Test_ClnLnd_Bitcoin_SwapIn|'\
-	'Test_ClnCln_ExcessiveAmount|'\
-	'Test_ClnCln_StuckChannels)'\
+	'Test_ClnCln_ExcessiveAmount)'\
 	 ./test
 .PHONY: test-bitoin-cln
 

--- a/packages.nix
+++ b/packages.nix
@@ -17,27 +17,15 @@ bitcoind = (pkgs.bitcoind.overrideAttrs (attrs: {
     };
 }));
 
-# Build a clightning version with developer features enabled.
-# Clightning is way more responsive with dev features.
-clightning-dev = (pkgs.clightning.overrideDerivation (attrs: {
-    configureFlags = [ "--disable-valgrind" ];
-
-    pname = "clightning-dev";
-    postInstall = ''
-        mv $out/bin/lightningd $out/bin/lightningd-dev
-    '';
-}));
-
 in with pkgs;
 {
     execs = {
         clightning = clightning;
-        clightning-dev = clightning-dev;
         bitcoind = bitcoind;
         elementsd = elementsd;
         mermaid = nodePackages.mermaid-cli;
         lnd = lnd;
     };
-    testpkgs = [ go bitcoind elementsd clightning-dev lnd ];
-    devpkgs = [ go_1_19 gotools bitcoind elementsd clightning clightning-dev lnd ];
+    testpkgs = [ go bitcoind elementsd lnd ];
+    devpkgs = [ go_1_19 gotools bitcoind elementsd clightning lnd ];
 }

--- a/packages.nix
+++ b/packages.nix
@@ -1,11 +1,11 @@
 let
-# Pinning to revision be28f5521e1d3fec2bd22928f721120725aba272
-# - cln v23.08 (with fix for clnrest.py crash on NixOS)
-# - lnd v0.16.3-beta
-# - bitcoin v25.0
-# - elements v22.1.1
+# Pinning to revision c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed
+# - cln v23.11
+# - lnd v0.17.0-beta
+# - bitcoin v25.1
+# - elements v23.2.1
 
-rev = "be28f5521e1d3fec2bd22928f721120725aba272";
+rev = "c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
 
@@ -20,7 +20,7 @@ bitcoind = (pkgs.bitcoind.overrideAttrs (attrs: {
 # Build a clightning version with developer features enabled.
 # Clightning is way more responsive with dev features.
 clightning-dev = (pkgs.clightning.overrideDerivation (attrs: {
-    configureFlags = [ "--enable-developer" "--disable-valgrind" ];
+    configureFlags = [ "--disable-valgrind" ];
 
     pname = "clightning-dev";
     postInstall = ''

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     alias bitcoin-cli='${execs.bitcoind}/bin/bitcoin-cli'
     alias elementsd='${execs.elementsd}/bin/elementsd'
     alias elements-cli='${execs.elementsd}/bin/elements-cli'
-    alias lightningd-dev='${execs.clightning-dev}/bin/lightningd-dev'
     alias lnd='${execs.lnd}/bin/lnd'
     alias lncli='${execs.lnd}/bin/lncli'
 

--- a/test/setup.go
+++ b/test/setup.go
@@ -81,8 +81,8 @@ func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64, clnConf []stri
 			os.ModePerm,
 		)
 
-		// Use lightningd with dev flags enabled
-		lightningd.WithCmd("lightningd-dev")
+		// Use lightningd with --developer turned on 
+		lightningd.WithCmd("lightningd")
 
 		// Add plugin to cmd line options
 		lightningd.AppendCmdLine(append([]string{fmt.Sprint("--plugin=", pathToPlugin)}, clnConf...))
@@ -243,8 +243,8 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 		os.ModePerm,
 	)
 
-	// Use lightningd with dev flags enabled
-	cln.WithCmd("lightningd-dev")
+	// Use lightningd with --developer turned on 
+	cln.WithCmd("lightningd")
 
 	// Add plugin to cmd line options
 	cln.AppendCmdLine([]string{
@@ -405,8 +405,8 @@ func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 			os.ModePerm,
 		)
 
-		// Use lightningd with dev flags enabled
-		lightningd.WithCmd("lightningd-dev")
+		// Use lightningd with --developer turned on 
+		lightningd.WithCmd("lightningd")
 
 		// Add plugin to cmd line options
 		lightningd.AppendCmdLine([]string{
@@ -665,8 +665,8 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 		os.ModePerm,
 	)
 
-	// Use lightningd with dev flags enabled
-	cln.WithCmd("lightningd-dev")
+	// Use lightningd with --developer turned on 
+	cln.WithCmd("lightningd")
 
 	// Add plugin to cmd line options
 	cln.AppendCmdLine([]string{

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -83,6 +83,7 @@ func NewCLightningNode(testDir string, bitcoin *BitcoinNode, id int) (*CLightnin
 		fmt.Sprintf("--bitcoin-rpcport=%s", bitcoinRpcPort),
 		fmt.Sprintf("--bitcoin-datadir=%s", bitcoin.DataDir),
 		fmt.Sprintf("--developer"),
+		fmt.Sprintf("--allow-deprecated-apis=true"),
 	}
 
 	// socketPath := filepath.Join(networkDir, "lightning-rpc")

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -82,6 +82,7 @@ func NewCLightningNode(testDir string, bitcoin *BitcoinNode, id int) (*CLightnin
 		fmt.Sprintf("--bitcoin-rpcpassword=%s", bitcoinRpcPass),
 		fmt.Sprintf("--bitcoin-rpcport=%s", bitcoinRpcPort),
 		fmt.Sprintf("--bitcoin-datadir=%s", bitcoin.DataDir),
+		fmt.Sprintf("--developer"),
 	}
 
 	// socketPath := filepath.Join(networkDir, "lightning-rpc")


### PR DESCRIPTION
Bumps daemons to the following:

cln v23.11.1
lnd v0.17.0-beta
bitcoin v25.1
elements v23.2.1

Also adds `--developer` flag to the testframework CLN config since `--enable-developer` is removed in the latest CLN. 


Fixes #249 