### PR TITLE
cln: remove wumbo check because CLN >=v23.11 defaults to enabling it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,6 @@ test-misc-integration: test-bins
 	'Test_RestoreFromPassedCSV|'\
 	'Test_Recover_PassedSwap_BTC|'\
 	'Test_Recover_PassedSwap_LBTC|'\
-	'Test_Wumbo|'\
 	'Test_ClnConfig|'\
 	'Test_ClnPluginConfigFile|'\
 	'Test_ClnPluginConfigFile_DoesNotExist|'\


### PR DESCRIPTION
Latest CLN ignores `large-channels` / `wumbo` config options and does not pass them to PeerSwap. PeerSwap checks for this config option and cancels large swaps if it is missing. This PR removes `ClnMaxPaymentSizeMsat` and the check since we don't need it anymore for CLN >=23.11.

Fixes #261