### PR TITLE
lnd: label the tx to make it easier to audit

### DIFF
--- a/clightning/clightning_wallet.go
+++ b/clightning/clightning_wallet.go
@@ -199,6 +199,14 @@ func (cl *ClightningClient) CreateCoopSpendingTransaction(swapParams *swap.Openi
 	return spendingTx.TxHash().String(), txHex, nil
 }
 
+func (cl *ClightningClient) LabelTransaction(txId, label string) error {
+	// todo implement
+	// This function assigns an identifiable label to the target transaction based on the txid.
+	// Currently no such functionality is available, so it has not been implemented.
+	// Supported by lnd only.
+	return nil
+}
+
 func (cl *ClightningClient) NewAddress() (string, error) {
 	newAddr, err := cl.glightning.NewAddr()
 	if err != nil {

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -1,0 +1,36 @@
+package labels
+
+import "fmt"
+
+const (
+	// peerswapLabelPattern is the pattern that peerswap uses to label on-chain transactions.
+	peerswapLabelPattern = "peerswap -- %s(swap id=%s)"
+	// opening is the label used for the opening transaction.
+	opening = "Opening"
+	// claimByInvoice is the label used for the claim by invoice transaction.
+	claimByInvoice = "ClaimByInvoice"
+	// claimByCoop is the label used for the claim by cooperative close transaction.
+	claimByCoop = "ClaimByCoop"
+	// ClaimByCsv is the label used for the claim by CSV transaction.
+	claimByCsv = "ClaimByCsv"
+)
+
+// Opening returns the label used for the opening transaction.
+func Opening(swapID string) string {
+	return fmt.Sprintf(peerswapLabelPattern, opening, swapID)
+}
+
+// ClaimByInvoice returns the label used for the claim by invoice transaction.
+func ClaimByInvoice(swapID string) string {
+	return fmt.Sprintf(peerswapLabelPattern, claimByInvoice, swapID)
+}
+
+// ClaimByCoop returns the label used for the claim by cooperative close transaction.
+func ClaimByCoop(swapID string) string {
+	return fmt.Sprintf(peerswapLabelPattern, claimByCoop, swapID)
+}
+
+// ClaimByCsv returns the label used for the claim by CSV transaction.
+func ClaimByCsv(swapID string) string {
+	return fmt.Sprintf(peerswapLabelPattern, claimByCsv, swapID)
+}

--- a/lnd/lnd_wallet.go
+++ b/lnd/lnd_wallet.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/elementsproject/peerswap/lightning"
 	"github.com/elementsproject/peerswap/onchain"
@@ -205,6 +206,22 @@ func (l *Client) CreateCoopSpendingTransaction(swapParams *swap.OpeningParams, c
 		return "", "", err
 	}
 	return spendingTx.TxHash().String(), txHex, nil
+}
+
+// LabelTransaction labels a transaction with a given label.
+// This makes it easier to audit the transactions from faraday.
+// This is performed by LND's LabelTransaction RPC.
+func (l *Client) LabelTransaction(txID, label string) error {
+	txIDHash, err := chainhash.NewHashFromStr(txID)
+	if err != nil {
+		return err
+	}
+	_, err = l.walletClient.LabelTransaction(l.ctx,
+		&walletrpc.LabelTransactionRequest{
+			Txid:      txIDHash.CloneBytes(),
+			Label:     label,
+			Overwrite: true})
+	return err
 }
 
 func (l *Client) GetOnchainBalance() (uint64, error) {

--- a/onchain/bitcoin.go
+++ b/onchain/bitcoin.go
@@ -254,6 +254,14 @@ func (b *BitcoinOnChain) PrepareSpendingTransaction(swapParams *swap.OpeningPara
 	return spendingTx, sigHash, redeemScript, nil
 }
 
+func (b *BitcoinOnChain) LabelTransaction(txID, label string) error {
+	// TODO: implement
+	// This function assigns an identifiable label to the target transaction based on the txid.
+	// Currently no such functionality is available, so it has not been implemented.
+	// Supported by lnd only.
+	return nil
+}
+
 func (b *BitcoinOnChain) CreateOpeningAddress(params *swap.OpeningParams, csv uint32) (string, error) {
 	redeemScript, err := ParamsToTxScript(params, csv)
 	if err != nil {

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -220,6 +220,14 @@ func (l *LiquidOnChain) CreateCoopSpendingTransaction(swapParams *swap.OpeningPa
 	return txId, txHex, nil
 }
 
+func (l *LiquidOnChain) LabelTransaction(txID, label string) error {
+	// TODO: implement
+	// This function assigns an identifiable label to the target transaction based on the txid.
+	// Currently no such functionality is available, so it has not been implemented.
+	// Supported by lnd only.
+	return nil
+}
+
 func (l *LiquidOnChain) AddBlindingRandomFactors(claimParams *swap.ClaimParams) (err error) {
 	claimParams.OutputAssetBlindingFactor = generateRandom32Bytes()
 	claimParams.BlindingSeed = generateRandom32Bytes()

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -721,7 +721,7 @@ type ValidateTxAndPayClaimInvoiceAction struct{}
 
 func (p *ValidateTxAndPayClaimInvoiceAction) Execute(services *SwapServices, swap *SwapData) EventType {
 	lc := services.lightning
-	onchain, wallet, validator, err := services.getOnChainServices(swap.GetChain())
+	onchain, _, validator, err := services.getOnChainServices(swap.GetChain())
 	if err != nil {
 		return swap.HandleError(err)
 	}
@@ -733,15 +733,6 @@ func (p *ValidateTxAndPayClaimInvoiceAction) Execute(services *SwapServices, swa
 	}
 	if !ok {
 		return swap.HandleError(errors.New("tx is not valid"))
-	}
-	txId, err := validator.TxIdFromHex(swap.OpeningTxHex)
-	if err != nil {
-		return swap.HandleError(err)
-	}
-	err = wallet.LabelTransaction(txId, labels.Opening(swap.GetId().Short()))
-	if err != nil {
-		log.Infof("Error labeling transaction. txid: %s, label: %s, error: %v",
-			txId, labels.Opening(swap.GetId().Short()), err)
 	}
 
 	var retryTime time.Duration = 120 * time.Second

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	BitcoinCsv = 1008
-	LiquidCsv  = 60
+	BitcoinCsv    = 1008
+	LiquidCsv     = 60
+	peerswapLabel = "peerswap"
 )
 
 type CheckRequestWrapperAction struct {
@@ -194,6 +195,10 @@ func (s *ClaimSwapTransactionWithPreimageAction) Execute(services *SwapServices,
 			return Event_OnRetry
 		}
 		swap.ClaimTxId = txId
+		err = wallet.LabelTransaction(txId, peerswapLabel)
+		if err != nil {
+			log.Infof("Error labeling trnasaction %v", err)
+		}
 	}
 
 	return Event_ActionSucceeded
@@ -248,6 +253,10 @@ func (c *CreateAndBroadcastOpeningTransaction) Execute(services *SwapServices, s
 	if err != nil {
 		// todo: idempotent states
 		return swap.HandleError(err)
+	}
+	err = wallet.LabelTransaction(txId, peerswapLabel)
+	if err != nil {
+		log.Infof("Error labeling trnasaction %v", err)
 	}
 	startingHeight, err := txWatcher.GetBlockHeight()
 	if err != nil {
@@ -437,6 +446,10 @@ func (c *ClaimSwapTransactionWithCsv) Execute(services *SwapServices, swap *Swap
 			return Event_OnRetry
 		}
 		swap.ClaimTxId = txId
+		err = wallet.LabelTransaction(txId, peerswapLabel)
+		if err != nil {
+			log.Infof("Error labeling trnasaction %v", err)
+		}
 	}
 
 	return Event_ActionSucceeded
@@ -463,6 +476,10 @@ func (c *ClaimSwapTransactionCoop) Execute(services *SwapServices, swap *SwapDat
 			return swap.HandleError(err)
 		}
 		swap.ClaimTxId = txId
+		err = wallet.LabelTransaction(txId, peerswapLabel)
+		if err != nil {
+			log.Infof("Error labeling trnasaction %v", err)
+		}
 	}
 
 	return Event_ActionSucceeded

--- a/swap/services.go
+++ b/swap/services.go
@@ -74,6 +74,7 @@ type Wallet interface {
 	CreatePreimageSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams) (string, string, error)
 	CreateCsvSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams) (txId, txHex string, error error)
 	CreateCoopSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams, takerSigner Signer) (txId, txHex string, error error)
+	LabelTransaction(txId, label string) error
 	GetOutputScript(params *OpeningParams) ([]byte, error)
 	NewAddress() (string, error)
 	GetRefundFee() (uint64, error)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -455,6 +455,11 @@ func (s *SwapId) FromString(str string) error {
 	return nil
 }
 
+// Short returns a shortened version of the id suitable for use in observing.
+func (s *SwapId) Short() string {
+	return s.String()[:6]
+}
+
 func ParseSwapIdFromString(str string) (*SwapId, error) {
 	data, err := hex.DecodeString(str)
 	if err != nil {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -458,6 +458,10 @@ func (d *dummyChain) AddWaitForConfirmationTx(swapId, txId string, vout, startin
 
 }
 
+func (d *dummyChain) LabelTransaction(txId, label string) error {
+	return nil
+}
+
 func (d *dummyChain) AddWaitForCsvTx(swapId, txId string, vout uint32, startingHeight uint32, wantscript []byte) {
 
 }


### PR DESCRIPTION
Ensure that all lnd transactions related to peerswaps are identifiable by the label `peerswap`.
This makes it easier to audit the transactions from faraday.   
This is performed by LND's LabelTransaction RPC.

If it fails, it is logged and subsequent processing is continued.

https://github.com/ElementsProject/peerswap/issues/254.

Samples are shown below.
* `peerswap -- Opening(swap id=b171ee)`
* `peerswap -- ClaimByCoop(swap id=b171ee)`
* `peerswap -- ClaimByCsv(swap id=b171ee)`
* `peerswap -- ClaimByInvoice(swap id=b171ee)`