### PR TITLE
[skip ci]docs: transaction labels for on-chain transactions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,7 @@ For LND:
 `pscli allowswaprequests --allow_swaps=[bool] ## true to allow, false to disallow`
 
 ## transaction labels
+To make the related transactions identifiable, peerswap sets the label.
 The label of the on-chain transaction corresponding to the swap is set as follows.
 
 * peerswap -- Opening(swap id=b171ee)
@@ -194,5 +195,12 @@ The label of the on-chain transaction corresponding to the swap is set as follow
 * peerswap -- ClaimByCsv(swap id=b171ee)
 * peerswap -- ClaimByInvoice(swap id=b171ee)
 
-For now, there is a limitation that only peerswap LNDs have on-chain labels.  
+The way the label is set up in each wallet is different.
+
+For CLN:
+Currently, it is not possible to set a label on the cln wallet
+
+For LND:
 To check the label attached to a transaction use `lncli listchaintxns`.
+
+For LBTC transactions, elementsd `SetLabel` will attach a label to the associated address.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,3 +185,14 @@ For CLN:
 `lightning-cli peerswap-allowswaprequests [bool] ## 1 to allow, 0 to disallow`
 For LND:
 `pscli allowswaprequests --allow_swaps=[bool] ## true to allow, false to disallow`
+
+## transaction labels
+The label of the on-chain transaction corresponding to the swap is set as follows.
+
+* peerswap -- Opening(swap id=b171ee)
+* peerswap -- ClaimByCoop(swap id=b171ee)
+* peerswap -- ClaimByCsv(swap id=b171ee)
+* peerswap -- ClaimByInvoice(swap id=b171ee)
+
+For now, there is a limitation that only peerswap LNDs have on-chain labels.  
+To check the label attached to a transaction use `lncli listchaintxns`.


### PR DESCRIPTION
Add information about setting transaction labels for on-chain transactions related to swaps.
Mention limitation that only peerswap LNDs have on-chain labels for now.

Related https://github.com/ElementsProject/peerswap/pull/283#issuecomment-1953333046