### PR TITLE
[skip ci] docs: add note about http:// for rpchost config option

### DIFF
--- a/docs/setup_cln.md
+++ b/docs/setup_cln.md
@@ -56,7 +56,7 @@ policypath="/path/to/policy" ## Path to policy file (default: $HOME/.lightning/<
 [Bitcoin]
 rpcuser="user"
 rpcpassword="password"
-rpchost="host"
+rpchost="http://host" ## the http:// is mandatory
 rpcport=1234
 cookiefilepath="/path/to/auth/.cookie" ## If set this will be used for authentication
 bitcoinswaps=true ## If set to false, BTC mainchain swaps are disabled
@@ -66,7 +66,7 @@ bitcoinswaps=true ## If set to false, BTC mainchain swaps are disabled
 [Liquid]
 rpcuser="user"
 rpcpassword="password"
-rpchost="host"
+rpchost="http://host" ## the http:// is mandatory 
 rpcport=1234
 rpcpasswordfile="/path/to/auth/.cookie" ## If set this will be used for authentication
 rpcwallet="swap-wallet" ## (default: peerswap)

--- a/docs/setup_lnd.md
+++ b/docs/setup_lnd.md
@@ -53,7 +53,7 @@ lnd.tlscertpath=/home/<username>/.lnd/tls.cert
 lnd.macaroonpath=/home/<username>/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 elementsd.rpcuser=<REPLACE_ME>
 elementsd.rpcpass=<REPLACE_ME>
-elementsd.rpchost=http://127.0.0.1
+elementsd.rpchost=http://127.0.0.1 # the http:// is mandatory
 elementsd.rpcport=<REPLACE_ME>
 elementsd.rpcwallet=peerswap
 elementsd.liquidswaps=true # set to false to manually disable L-BTC swaps
@@ -70,7 +70,7 @@ lnd.tlscertpath=/home/<username>/.lnd/tls.cert
 lnd.macaroonpath=/home/<username>/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 elementsd.rpcuser=<REPLACE_ME>
 elementsd.rpcpass=<REPLACE_ME>
-elementsd.rpchost=http://127.0.0.1
+elementsd.rpchost=http://127.0.0.1 # the http:// is mandatory
 elementsd.rpcport=<REPLACE_ME>
 elementsd.rpcwallet=peerswap
 EOF

--- a/docs/signetguide_cln.md
+++ b/docs/signetguide_cln.md
@@ -8,7 +8,7 @@ PeerSwap requires _core-lightning_, _bitcoind_ and an _elementsd_ installation i
 
 ## Bitcoind (signet)
 
-Download the following files to install Bitcoin Core.
+Download the following files to install Bitcoin Core. Make sure to download the latest release.
 
 ```bash
 wget https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-linux-gnu.tar.gz && \
@@ -49,7 +49,7 @@ bitcoind --signet --daemon
 
 ## Liquid testnet (optional)
 
-Download the following files to install elementsd.
+Download the following files to install elementsd. Make sure to download the latest release.
 
 ```bash
 wget https://github.com/ElementsProject/elements/releases/download/elements-0.21.0.2/elements-elements-0.21.0.2-x86_64-linux-gnu.tar.gz && \
@@ -94,37 +94,15 @@ chain=liquidtestnet
 # Liquid Testnet (liquidtestnet) settings:
 [liquidtestnet]
 
-# General settings:
 listen=1
 txindex=1
 validatepegin=0
-anyonecanspendaremine=0
-initialfreecoins=2100000000000000
-con_dyna_deploy_start=0
-con_max_block_sig_size=150
-checkblockindex=0 
-addnode=liquid-testnet.blockstream.com:18892
-addnode=liquidtestnet.com:18891
 fallbackfee=0.00000100
 daemon=1
-con_has_parent_chain=0
-parentgenesisblockhash=NULL
-pubkeyprefix=36
-scriptprefix=19
-blindedprefix=23
-bech32_hrp=tex
-blech32_hrp=tlq
-pchmessagestart=410edd62
-dynamic_epoch_length=1000
-signblockscript=51210217e403ddb181872c32a0cd468c710040b2f53d8cac69f18dad07985ee37e9a7151ae
-
 rpcport=18884
 rpcuser=admin1
 rpcpassword=123
 rpcbind=127.0.0.1
-addnode=95.217.184.148:18444
-evbparams=dynafed:0:::
-multi_data_permitted=1
 EOF
 ```
 
@@ -217,7 +195,7 @@ touch $HOME/.lightning/signet/peerswap/peerswap.conf
 echo '[Liquid]
 rpcuser="admin1"
 rpcpassword="123"
-rpchost="http://localhost"
+rpchost="http://localhost" # the http:// is mandatory
 rpcport=18884
 rpcwallet="swap"' > $HOME/.lightning/signet/peerswap.conf
 ```


### PR DESCRIPTION
Seems like on Discord we've been getting a steady stream of people getting stuck with peerswap complaining about the `rpchost` config option. This adds a note that the `http://` in the `rpchost` is mandatory.

Also slimmed down the signet CLN guide's elementsd config since 90% of the config options are enabled with `chain=liquidtestnet` now. 