### PR TITLE
bump nixpkgs and go version

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -1,11 +1,11 @@
 let
-# Pinning to revision c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed
-# - cln v23.11
-# - lnd v0.17.0-beta
-# - bitcoin v25.1
+# Pinning to revision f54322490f509985fa8be4ac9304f368bd8ab924 
+# - cln v24.02.1
+# - lnd v0.17.4-beta
+# - bitcoin v26.0
 # - elements v23.2.1
 
-rev = "c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed";
+rev = "f54322490f509985fa8be4ac9304f368bd8ab924";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
 
@@ -27,5 +27,6 @@ in with pkgs;
         lnd = lnd;
     };
     testpkgs = [ go bitcoind elementsd lnd ];
-    devpkgs = [ go_1_19 gotools bitcoind elementsd clightning lnd ];
+    devpkgs = [ go_1_22 gotools bitcoind elementsd clightning lnd ];
+
 }


### PR DESCRIPTION
This bumps `go` to 1.22 since 1.19 is EOL now. 

This also updates the test daemons to:

cln v24.02.1
lnd v0.17.4-beta
bitcoin v26.0