### PR TITLE
Update nix pkgs

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -1,11 +1,11 @@
 let
-# Pinning to revision c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed
-# - cln v23.11
-# - lnd v0.17.0-beta
-# - bitcoin v25.1
+# Pinning to revision f54322490f509985fa8be4ac9304f368bd8ab924 
+# - cln v24.02.1
+# - lnd v0.17.4-beta
+# - bitcoin v26.0
 # - elements v23.2.1
 
-rev = "c8a66e2bb84c2b9cf7014a61c44ffb13ef4317ed";
+rev = "f54322490f509985fa8be4ac9304f368bd8ab924";
 nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 pkgs = import nixpkgs {};
 
@@ -27,5 +27,6 @@ in with pkgs;
         lnd = lnd;
     };
     testpkgs = [ go bitcoind elementsd lnd ];
-    devpkgs = [ go_1_19 gotools bitcoind elementsd clightning lnd ];
+    devpkgs = [ go_1_22 gotools bitcoind elementsd clightning lnd ];
+
 }

--- a/test/bitcoin_cln_test.go
+++ b/test/bitcoin_cln_test.go
@@ -1157,7 +1157,8 @@ func Test_ClnCln_StuckChannels(t *testing.T) {
 		"--dev-fast-gossip",
 		"--large-channels",
 		"--min-capacity-sat=1000",
-	})
+		"--min-emergency-msat=600000",
+	}, false)
 
 	defer func() {
 		if t.Failed() {

--- a/test/setup.go
+++ b/test/setup.go
@@ -35,10 +35,11 @@ func clnclnSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNode, []*t
 		"--dev-bitcoind-poll=1",
 		"--dev-fast-gossip",
 		"--large-channels",
-	})
+	}, true)
 }
 
-func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64, clnConf []string) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
+func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64,
+	clnConf []string, waitForActiveChannel bool) (*testframework.BitcoinNode, []*testframework.CLightningNode, string) {
 	// Get PeerSwap plugin path and test dir
 	_, filename, _, _ := runtime.Caller(0)
 	pathToPlugin := filepath.Join(filename, "..", "..", "out", "test-builds", "peerswap")
@@ -81,7 +82,7 @@ func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64, clnConf []stri
 			os.ModePerm,
 		)
 
-		// Use lightningd with --developer turned on 
+		// Use lightningd with --developer turned on
 		lightningd.WithCmd("lightningd")
 
 		// Add plugin to cmd line options
@@ -108,7 +109,7 @@ func clnclnSetupWithConfig(t *testing.T, fundAmt, pushAmt uint64, clnConf []stri
 	}
 
 	// Setup channel ([0] fundAmt(10^7) ---- 0 [1])
-	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, pushAmt, true, true, true)
+	scid, err := lightningds[0].OpenChannel(lightningds[1], fundAmt, pushAmt, true, true, waitForActiveChannel)
 	if err != nil {
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
@@ -243,7 +244,7 @@ func mixedSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*testframewor
 		os.ModePerm,
 	)
 
-	// Use lightningd with --developer turned on 
+	// Use lightningd with --developer turned on
 	cln.WithCmd("lightningd")
 
 	// Add plugin to cmd line options
@@ -405,7 +406,7 @@ func clnclnElementsSetup(t *testing.T, fundAmt uint64) (*testframework.BitcoinNo
 			os.ModePerm,
 		)
 
-		// Use lightningd with --developer turned on 
+		// Use lightningd with --developer turned on
 		lightningd.WithCmd("lightningd")
 
 		// Add plugin to cmd line options
@@ -665,7 +666,7 @@ func mixedElementsSetup(t *testing.T, fundAmt uint64, funder fundingNode) (*test
 		os.ModePerm,
 	)
 
-	// Use lightningd with --developer turned on 
+	// Use lightningd with --developer turned on
 	cln.WithCmd("lightningd")
 
 	// Add plugin to cmd line options

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -108,7 +108,7 @@ func Test_Wumbo(t *testing.T) {
 			}
 
 			// Test Swap-out
-			bitcoind, lightningds, scid := clnclnSetupWithConfig(t, maxChanSize, 0, options)
+			bitcoind, lightningds, scid := clnclnSetupWithConfig(t, maxChanSize, 0, options, true)
 			defer func() {
 				if t.Failed() {
 					filter := os.Getenv("PEERSWAP_TEST_FILTER")


### PR DESCRIPTION
https://github.com/ElementsProject/peerswap/pull/291, including responses to test case failures.

Anchor channels are now the default in >24.02.
We need to account for the min-emergency-msat now when opening a channel.

In the stuck channel test, the default min-emergency-msat of 25000sat is too large, so it is set to a smaller value slightly exceeding the dust limit.
