### PR TITLE
swap: add a recovery process for AwaitFeeInvoice

### DIFF
--- a/swap/swap_out_receiver.go
+++ b/swap/swap_out_receiver.go
@@ -56,7 +56,9 @@ func getSwapOutReceiverStates() States {
 			Events: Events{
 				Event_OnFeeInvoicePaid: State_SwapOutReceiver_BroadcastOpeningTx,
 				Event_OnCancelReceived: State_SwapCanceled,
+				Event_ActionFailed:     State_SendCancel,
 			},
+			FailOnrecover: true,
 		},
 		State_SwapOutReceiver_BroadcastOpeningTx: {
 			Action: &CreateAndBroadcastOpeningTransaction{},


### PR DESCRIPTION
`AwaitFeeInvoice`state to hang in case of state mismatch with peer. https://github.com/ElementsProject/peerswap/issues/290

To eliminate the persistence of uncompleted swaps, execute "cancel" if recovery by restart is executed in `AwaitFeeInvoice` state.