### PR TITLE
config: fix cln listconfig output

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -356,7 +356,7 @@ func (cl *ClightningClient) SetPeerswapConfig(config *Config) {
 		LiquidRpcHost:          config.Liquid.RpcHost,
 		LiquidRpcPort:          config.Liquid.RpcPort,
 		LiquidRpcWallet:        config.Liquid.RpcWallet,
-		LiquidDisabled:         *config.Liquid.LiquidSwaps,
+		LiquidEnabled:          *config.Liquid.LiquidSwaps,
 		PeerswapDir:            config.PeerswapDir,
 	}
 }

--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -356,7 +356,7 @@ func (cl *ClightningClient) SetPeerswapConfig(config *Config) {
 		LiquidRpcHost:          config.Liquid.RpcHost,
 		LiquidRpcPort:          config.Liquid.RpcPort,
 		LiquidRpcWallet:        config.Liquid.RpcWallet,
-		LiquidEnabled:          *config.Liquid.LiquidSwaps,
+		LiquidSwaps:          *config.Liquid.LiquidSwaps,
 		PeerswapDir:            config.PeerswapDir,
 	}
 }

--- a/clightning/options.go
+++ b/clightning/options.go
@@ -10,7 +10,7 @@ const (
 	liquidRpcUserOption             = "peerswap-elementsd-rpcuser"
 	liquidRpcPasswordOption         = "peerswap-elementsd-rpcpassword"
 	liquidRpcPasswordFilepathOption = "peerswap-elementsd-rpcpasswordfile"
-	liquidEnabledOption             = "peerswap-elementsd-enabled"
+	liquidSwapsOption             = "peerswap-elementsd-swaps"
 	liquidRpcWalletOption           = "peerswap-elementsd-rpcwallet"
 
 	bitcoinRpcHostOption     = "peerswap-bitcoin-rpchost"
@@ -53,7 +53,7 @@ type PeerswapClightningConfig struct {
 	LiquidRpcHost         string `json:"liquid.rpchost"`
 	LiquidRpcPort         uint   `json:"liquid.rpcport"`
 	LiquidRpcWallet       string `json:"liquid.rpcwallet"`
-	LiquidEnabled         bool   `json:"liquid.enabled"`
+	LiquidSwaps         bool   `json:"liquid.swaps"`
 
 	PeerswapDir string `json:"peerswap-dir"`
 }

--- a/clightning/options.go
+++ b/clightning/options.go
@@ -10,7 +10,7 @@ const (
 	liquidRpcUserOption             = "peerswap-elementsd-rpcuser"
 	liquidRpcPasswordOption         = "peerswap-elementsd-rpcpassword"
 	liquidRpcPasswordFilepathOption = "peerswap-elementsd-rpcpasswordfile"
-	liquidDisabledOption            = "peerswap-elementsd-disabled"
+	liquidEnabledOption             = "peerswap-elementsd-enabled"
 	liquidRpcWalletOption           = "peerswap-elementsd-rpcwallet"
 
 	bitcoinRpcHostOption     = "peerswap-bitcoin-rpchost"
@@ -28,7 +28,7 @@ var legacyOptions = []string{
 	liquidRpcUserOption,
 	liquidRpcPasswordOption,
 	liquidRpcPasswordFilepathOption,
-	liquidDisabledOption,
+	liquidEnabledOption,
 	liquidRpcWalletOption,
 	bitcoinRpcHostOption,
 	bitcoinRpcPortOption,
@@ -53,7 +53,7 @@ type PeerswapClightningConfig struct {
 	LiquidRpcHost         string `json:"liquid.rpchost"`
 	LiquidRpcPort         uint   `json:"liquid.rpcport"`
 	LiquidRpcWallet       string `json:"liquid.rpcwallet"`
-	LiquidDisabled        bool   `json:"liquid.disabled"`
+	LiquidEnabled         bool   `json:"liquid.enabled"`
 
 	PeerswapDir string `json:"peerswap-dir"`
 }
@@ -112,7 +112,7 @@ func (cl *ClightningClient) RegisterOptions() error {
 		return err
 	}
 
-	err = cl.Plugin.RegisterNewBoolOption(liquidDisabledOption, "enable/disable liquid", false)
+	err = cl.Plugin.RegisterNewBoolOption(liquidEnabledOption, "enable/disable liquid", false)
 	if err != nil {
 		return err
 	}

--- a/clightning/options.go
+++ b/clightning/options.go
@@ -28,7 +28,7 @@ var legacyOptions = []string{
 	liquidRpcUserOption,
 	liquidRpcPasswordOption,
 	liquidRpcPasswordFilepathOption,
-	liquidEnabledOption,
+	liquidSwapsOption,
 	liquidRpcWalletOption,
 	bitcoinRpcHostOption,
 	bitcoinRpcPortOption,
@@ -112,7 +112,7 @@ func (cl *ClightningClient) RegisterOptions() error {
 		return err
 	}
 
-	err = cl.Plugin.RegisterNewBoolOption(liquidEnabledOption, "enable/disable liquid", false)
+	err = cl.Plugin.RegisterNewBoolOption(liquidSwapsOption, "enable/disable liquid", false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
CLN PeerSwap `listconfig` currently outputs a `liquid.disabled` field, which doesn't match how `liquidswaps` is set in the `peerswap.conf` file. The output will print as the opposite of how `liquidswaps` is set. This should fix it to properly match how the config option is set.