### PR TITLE
clightning: use CLN's listpeerchannels instead

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -647,9 +647,12 @@ func (l *ListPeers) Call() (jrpc2.Result, error) {
 				},
 				PaidFee: paidFees,
 			}
-
+			channels, err := l.cl.glightning.ListChannelsBySource(peer.Id)
+			if err != nil {
+				return nil, err
+			}
 			peerSwapPeerChannels := []*PeerSwapPeerChannel{}
-			for _, channel := range peer.Channels {
+			for _, channel := range channels {
 				if c, ok := fundingChannels[channel.ShortChannelId]; ok {
 					peerSwapPeerChannels = append(peerSwapPeerChannels, &PeerSwapPeerChannel{
 						ChannelId:     c.ShortChannelId,


### PR DESCRIPTION
The channels field was removed from listpeers in CLN v24.05. 
This means that the peerswap-listpeers command also does not have this field.

Ensure that listchannels are used so that they are still visible in CLN v24.05 and later.
This is a backwards-compatible change that will continue to be displayed in CLN v24.05 and earlier.

Confirmed to work with v24.05 and v23.11.

Fixes https://github.com/ElementsProject/peerswap/issues/299.

