### PR TITLE
wallet: add fee rate estimation to FundRawTx

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -362,34 +362,16 @@ func (l *SwapIn) Call() (jrpc2.Result, error) {
 	if !l.cl.isPeerConnected(fundingChannels.Id) {
 		return nil, fmt.Errorf("peer is not connected")
 	}
-	if l.Asset == "lbtc" {
+	switch l.Asset {
+	case "lbtc":
 		if !l.cl.swaps.LiquidEnabled {
 			return nil, errors.New("liquid swaps are not enabled")
 		}
-		liquidBalance, err := l.cl.liquidWallet.GetBalance()
-		if err != nil {
-			return nil, err
-		}
-		if liquidBalance < l.SatAmt {
-			return nil, errors.New("Not enough balance on liquid liquidWallet")
-		}
-	} else if l.Asset == "btc" {
+	case "btc":
 		if !l.cl.swaps.BitcoinEnabled {
 			return nil, errors.New("bitcoin swaps are not enabled")
 		}
-		funds, err := l.cl.glightning.ListFunds()
-		if err != nil {
-			return nil, err
-		}
-		sats := uint64(0)
-		for _, v := range funds.Outputs {
-			sats += v.AmountMilliSatoshi.MSat() / 1000
-		}
-
-		if sats < l.SatAmt+2000 {
-			return nil, errors.New("Not enough balance on c-lightning onchain liquidWallet")
-		}
-	} else {
+	default:
 		return nil, errors.New("invalid asset (btc or lbtc)")
 	}
 

--- a/clightning/clightning_wallet.go
+++ b/clightning/clightning_wallet.go
@@ -225,11 +225,11 @@ func (cl *ClightningClient) GetOnchainBalance() (uint64, error) {
 	return totalBalance, nil
 }
 
-// GetFlatSwapOutFee returns an estimated size for the opening transaction. This
+// GetFlatOpeningTXFee returns an estimated size for the opening transaction. This
 // can be used to calculate the amount of the fee invoice and should cover most
 // but not all cases. For an explanation of the estimation see comments of the
 // onchain.EstimatedOpeningTxSize.
-func (cl *ClightningClient) GetFlatSwapOutFee() (uint64, error) {
+func (cl *ClightningClient) GetFlatOpeningTXFee() (uint64, error) {
 	return cl.bitcoinChain.GetFee(onchain.EstimatedOpeningTxSize)
 }
 

--- a/lnd/lnd_wallet.go
+++ b/lnd/lnd_wallet.go
@@ -245,11 +245,11 @@ func (l *Client) GetRefundFee() (uint64, error) {
 	return l.bitcoinOnChain.GetFee(250)
 }
 
-// GetFlatSwapOutFee returns an estimated size for the opening transaction. This
+// GetFlatOpeningTXFee returns an estimated size for the opening transaction. This
 // can be used to calculate the amount of the fee invoice and should cover most
 // but not all cases. For an explanation of the estimation see comments of the
 // onchain.EstimatedOpeningTxSize.
-func (l *Client) GetFlatSwapOutFee() (uint64, error) {
+func (l *Client) GetFlatOpeningTXFee() (uint64, error) {
 	return l.bitcoinOnChain.GetFee(onchain.EstimatedOpeningTxSize)
 }
 

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -30,6 +30,10 @@ import (
 const (
 	LiquidCsv   = 60
 	LiquidConfs = 2
+	// EstimatedOpeningConfidentialTxSizeBytes is the estimated size of a opening transaction.
+	// The size is a calculate 2672 bytes for 3 inputs and 3 ouputs of which 2 are
+	// blinded. An additional safety margin is added for a total of 3000 bytes.
+	EstimatedOpeningConfidentialTxSizeBytes = 3000
 )
 
 type LiquidOnChain struct {
@@ -528,11 +532,9 @@ func (l *LiquidOnChain) GetRefundFee() (uint64, error) {
 	return l.liquidWallet.GetFee(int64(l.getClaimTxSize()))
 }
 
-// GetFlatSwapOutFee returns an estimate of the fee for the opening transaction.
-// The size is a calculate 2672 bytes for 3 inputs and 3 ouputs of which 2 are
-// blinded. An additional safety margin is added for a total of 3000 bytes.
-func (l *LiquidOnChain) GetFlatSwapOutFee() (uint64, error) {
-	return l.liquidWallet.GetFee(3000)
+// GetFlatOpeningTXFee returns an estimate of the fee for the opening transaction.
+func (l *LiquidOnChain) GetFlatOpeningTXFee() (uint64, error) {
+	return l.liquidWallet.GetFee(EstimatedOpeningConfidentialTxSizeBytes)
 }
 
 func (l *LiquidOnChain) GetAsset() string {

--- a/peerswaprpc/server.go
+++ b/peerswaprpc/server.go
@@ -219,31 +219,16 @@ func (p *PeerswapServer) SwapIn(ctx context.Context, request *SwapInRequest) (*S
 		return nil, errors.New("channel is not connected")
 	}
 
-	if request.Asset == "lbtc" {
+	switch request.Asset {
+	case "lbtc":
 		if !p.swaps.LiquidEnabled {
 			return nil, errors.New("liquid swaps are not enabled")
 		}
-
-		liquidBalance, err := p.liquidWallet.GetBalance()
-		if err != nil {
-			return nil, err
-		}
-		if liquidBalance < request.SwapAmount+1000 {
-			return nil, errors.New("Not enough balance on liquid wallet")
-		}
-	} else if request.Asset == "btc" {
+	case "btc":
 		if !p.swaps.BitcoinEnabled {
 			return nil, errors.New("bitcoin swaps are not enabled")
 		}
-		walletbalance, err := p.lnd.WalletBalance(ctx, &lnrpc.WalletBalanceRequest{})
-		if err != nil {
-			return nil, err
-		}
-		if uint64(walletbalance.ConfirmedBalance) < request.SwapAmount+2000 {
-			return nil, errors.New("Not enough balance on lnd onchain liquidWallet")
-		}
-
-	} else {
+	default:
 		return nil, errors.New("invalid asset (btc or lbtc)")
 	}
 

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -372,22 +372,18 @@ func (c *CreateSwapOutFromRequestAction) Execute(services *SwapServices, swap *S
 		return swap.HandleError(err)
 	}
 
-	openingFee, err := wallet.GetFlatSwapOutFee()
+	openingFee, err := wallet.GetFlatOpeningTXFee()
 	if err != nil {
 		swap.LastErr = err
 		return swap.HandleError(err)
 	}
 
-	// Check if onchain balance is sufficient for swap + fees + some safety net
+	// Check if onchain balance is sufficient for swap + fees
 	walletBalance, err := wallet.GetOnchainBalance()
 	if err != nil {
 		return swap.HandleError(err)
 	}
-
-	// TODO: this should be looked at in the future
-	safetynet := uint64(20000)
-
-	if walletBalance < swap.GetAmount()+openingFee+safetynet {
+	if walletBalance < swap.GetAmount()+openingFee {
 		return swap.HandleError(errors.New("insufficient walletbalance"))
 	}
 
@@ -621,7 +617,7 @@ func (r *PayFeeInvoiceAction) Execute(services *SwapServices, swap *SwapData) Ev
 
 	swap.OpeningTxFee = msatAmt / 1000
 
-	expectedFee, err := wallet.GetFlatSwapOutFee()
+	expectedFee, err := wallet.GetFlatOpeningTXFee()
 	if err != nil {
 		swap.LastErr = err
 		return swap.HandleError(err)

--- a/swap/services.go
+++ b/swap/services.go
@@ -78,7 +78,7 @@ type Wallet interface {
 	GetOutputScript(params *OpeningParams) ([]byte, error)
 	NewAddress() (string, error)
 	GetRefundFee() (uint64, error)
-	GetFlatSwapOutFee() (uint64, error)
+	GetFlatOpeningTXFee() (uint64, error)
 	GetAsset() string
 	GetNetwork() string
 	GetOnchainBalance() (uint64, error)

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -478,7 +478,7 @@ func (d *dummyChain) GetRefundFee() (uint64, error) {
 	return 100, nil
 }
 
-func (d *dummyChain) GetFlatSwapOutFee() (uint64, error) {
+func (d *dummyChain) GetFlatOpeningTXFee() (uint64, error) {
 	return 100, nil
 }
 


### PR DESCRIPTION
This is a fix for the inconvenience caused by the `FundRawTx` , which sometimes set relatively high fees.

Add `getFeeRate` function to estimate optimal fee rate based on network conditions.
Replace FundRawTx with FundRawWithOptions to support fee rate options.