### PR TITLE
liquid:  ct discount

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,17 +86,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1718716287,
-        "narHash": "sha256-rThaCGm+cfFwcAfwUzULZVZ/fdpD+nD37PyKhjWSX2M=",
+        "lastModified": 1728894785,
+        "narHash": "sha256-46HJYn1DJCp1+L+hUs8H90IkOsz2BDJVuYJI/pI/Jk4=",
         "owner": "blockstream",
         "repo": "lwk",
-        "rev": "14bac284fe712dd6fdbbbe82bda179a2a236b2fa",
+        "rev": "9ddd20a806625bb40cd063ad61d80d106809a9fd",
         "type": "github"
       },
       "original": {
         "owner": "blockstream",
         "repo": "lwk",
-        "rev": "14bac284fe712dd6fdbbbe82bda179a2a236b2fa",
+        "rev": "9ddd20a806625bb40cd063ad61d80d106809a9fd",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     # blockstream-electrs: init at 0.4.1 #299761
     # https://github.com/NixOS/nixpkgs/pull/299761/commits/680d27ad847801af781e0a99e4b87ed73965c69a
     nixpkgs2.url = "github:NixOS/nixpkgs/680d27ad847801af781e0a99e4b87ed73965c69a";
-    # lwk: init at wasm_0.6.3 #14bac28
-    # https://github.com/Blockstream/lwk/releases/tag/wasm_0.6.3
+    # lwk: init at 9ddd20a806625bb40cd063ad61d80d106809a9fd
+    # https://github.com/Blockstream/lwk/commit/9ddd20a806625bb40cd063ad61d80d106809a9fd
     lwk-flake = {
-      url = "github:blockstream/lwk/14bac284fe712dd6fdbbbe82bda179a2a236b2fa";
+      url = "github:blockstream/lwk/9ddd20a806625bb40cd063ad61d80d106809a9fd";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/lwk/client.go
+++ b/lwk/client.go
@@ -103,8 +103,9 @@ type unvalidatedAddressee struct {
 type sendRequest struct {
 	Addressees []*unvalidatedAddressee `json:"addressees"`
 	// Optional fee rate in sat/vb
-	FeeRate    *float64 `json:"fee_rate,omitempty"`
-	WalletName string   `json:"name"`
+	FeeRate          *float64 `json:"fee_rate,omitempty"`
+	WalletName       string   `json:"name"`
+	EnableCtDiscount bool     `json:"enable_ct_discount"`
 }
 
 type sendResponse struct {

--- a/lwk/error.go
+++ b/lwk/error.go
@@ -1,0 +1,37 @@
+package lwk
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// electrumRPCError represents the structure of an RPC error response
+type electrumRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Regular expression to match RPC error messages with any prefix
+var re = regexp.MustCompile(`^(.*) RPC error: (.*)$`)
+
+// parseRPCError parses an error and extracts the RPC error code and message if present
+func parseRPCError(err error) (*electrumRPCError, error) {
+	var rpcErr electrumRPCError
+	errStr := err.Error()
+
+	matches := re.FindStringSubmatch(errStr)
+
+	if len(matches) == 3 { // Prefix and JSON payload extracted successfully
+		errJSON := matches[2]
+		if jerr := json.Unmarshal([]byte(errJSON), &rpcErr); jerr != nil {
+			return nil, fmt.Errorf("error parsing rpc error: %v", jerr)
+		}
+	} else {
+		// If no RPC error pattern is found, return the original error
+		return nil, errors.New(errStr)
+	}
+
+	return &rpcErr, nil
+}

--- a/lwk/error_test.go
+++ b/lwk/error_test.go
@@ -1,0 +1,54 @@
+package lwk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseRPCError(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]struct {
+		err          error
+		expectedCode int
+		expectedMsg  string
+		wantErr      bool
+	}{
+		"Valid RPC error": {
+			err:          errors.New("sendrawtransaction RPC error: {\"code\":-26,\"message\":\"min relay fee not met\"}"),
+			expectedCode: -26,
+			expectedMsg:  "min relay fee not met",
+			wantErr:      false,
+		},
+		"Invalid JSON payload": {
+
+			err:          errors.New("RPC error: {invalid json}"),
+			expectedCode: 0,
+			expectedMsg:  "",
+			wantErr:      true,
+		},
+		"No RPC error pattern": {
+			err:          errors.New("Some other error"),
+			expectedCode: 0,
+			expectedMsg:  "",
+			wantErr:      true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			rpcErr, err := parseRPCError(tc.err)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("wantErr: %v, got error: %v", tc.wantErr, err)
+			}
+			if err == nil {
+				if rpcErr.Code != tc.expectedCode {
+					t.Errorf("expected code: %d, got: %d", tc.expectedCode, rpcErr.Code)
+				}
+				if rpcErr.Message != tc.expectedMsg {
+					t.Errorf("expected message: %s, got: %s", tc.expectedMsg, rpcErr.Message)
+				}
+			}
+		})
+	}
+}

--- a/lwk/lwkwallet.go
+++ b/lwk/lwkwallet.go
@@ -259,6 +259,13 @@ func (r *LWKRpcWallet) SendRawTx(txHex string) (string, error) {
 	defer cancel()
 	res, err := r.electrumClient.BroadcastTransaction(ctx, txHex)
 	if err != nil {
+		rpcErr, pErr := parseRPCError(err)
+		if pErr != nil {
+			return "", fmt.Errorf("error parsing rpc error: %v", pErr)
+		}
+		if rpcErr.Code == -26 {
+			return "", wallet.MinRelayFeeNotMetError
+		}
 		return "", err
 	}
 	return res, nil

--- a/lwk/lwkwallet.go
+++ b/lwk/lwkwallet.go
@@ -161,6 +161,7 @@ func (r *LWKRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.OpeningPar
 	ctx, cancel := context.WithTimeout(context.Background(), defaultContextTimeout)
 	defer cancel()
 	feerate := r.getFeeSatPerVByte(ctx).getValue() * kb
+	// todo: There will be an option in the tx builder to enable the discount.
 	fundedTx, err := r.lwkClient.send(ctx, &sendRequest{
 		Addressees: []*unvalidatedAddressee{
 			{

--- a/lwk/lwkwallet.go
+++ b/lwk/lwkwallet.go
@@ -30,7 +30,7 @@ const (
 	// Set up here because ctx is not inherited throughout the current codebase.
 	defaultContextTimeout             = time.Second * 20
 	minimumFee            SatPerVByte = 0.1
-	supportedCLIVersion               = "0.5.1"
+	supportedCLIVersion               = "0.8.0"
 )
 
 func SatPerVByteFromFeeBTCPerKb(feeBTCPerKb float64) SatPerVByte {
@@ -169,8 +169,9 @@ func (r *LWKRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.OpeningPar
 				Satoshi: swapParams.Amount,
 			},
 		},
-		WalletName: r.c.GetWalletName(),
-		FeeRate:    &feerate,
+		WalletName:       r.c.GetWalletName(),
+		FeeRate:          &feerate,
+		EnableCtDiscount: true,
 	})
 	if err != nil {
 		return "", "", 0, fmt.Errorf("failed to fund transaction: %w", err)
@@ -233,6 +234,7 @@ func (r *LWKRpcWallet) SendToAddress(address string, amount Satoshi) (string, er
 				Satoshi: amount,
 			},
 		},
+		EnableCtDiscount: true,
 	})
 	if err != nil {
 		return "", err

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -443,21 +443,35 @@ const (
 	transactionKindCSV              transactionKind = "csv"
 )
 
+// getEstimatedTxSize estimates the size of a transaction based on its kind and whether it's using Confidential Transactions (CT).
 func getEstimatedTxSize(t transactionKind, ctDiscount bool) int {
 	txsize := 0
 	switch t {
 	case transactionKindPreimageSpending:
+		// Preimage spending transactions have an estimated size of 1350 bytes.
 		txsize = 1350
 	case transactionKindCoop:
+		// Cooperative close transactions have an estimated size of 1360 bytes.
 		txsize = 1360
 	case transactionKindOpening:
+		// Opening transactions have a variable size, estimated in the constant EstimatedOpeningConfidentialTxSizeBytes.
 		txsize = EstimatedOpeningConfidentialTxSizeBytes
 	case transactionKindCSV:
+		// CSV transactions have an estimated size of 1350 bytes.
 		txsize = 1350
 	default:
+		// For unknown transaction types, assume a default size of 1360 bytes.
 		return 1360
 	}
 	if ctDiscount {
+		// If CT is enabled, the transaction size is reduced by 75%.
+		// TODO:
+		//   This is a placeholder value, the actual discount should
+		//   be calculated based on discount vsize.
+		//   To do this, we would need to construct the transaction, decode it, and then get the discounted vsize.
+		//   However, this would have a significant impact on the codebase.
+		//   As a temporary measure, we're taking a conservative approach and applying a 75% discount.
+		//   For the discount calculation, refer to https://github.com/ElementsProject/ELIPs/blob/main/elip-0200.mediawiki.
 		return txsize / 4
 	}
 	return txsize

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -81,14 +81,38 @@ func (l *LiquidOnChain) CreateOpeningTransaction(swapParams *swap.OpeningParams)
 	return txHex, blindedScriptAddr, txId, fee, vout, nil
 }
 
+// feeAmountPlaceholder is a placeholder for the fee amount
+const feeAmountPlaceholder = uint64(500)
+
 func (l *LiquidOnChain) CreatePreimageSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams) (string, string, string, error) {
+	fee, err := l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindPreimageSpending, true)))
+	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	txId, txHex, newAddr, err := l.createPreimageSpendingTransaction(swapParams, claimParams, fee)
+	if err == nil {
+		return txId, txHex, newAddr, nil
+	}
+	if !errors.Is(err, wallet.MinRelayFeeNotMetError) {
+		return "", "", "", err
+	}
+	fee, err = l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindPreimageSpending, false)))
+	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	return l.createPreimageSpendingTransaction(swapParams, claimParams, fee)
+}
+
+func (l *LiquidOnChain) createPreimageSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams, fee uint64) (string, string, string, error) {
 	newAddr, err := l.liquidWallet.GetAddress()
 	if err != nil {
 		return "", "", "", err
 	}
 	l.AddBlindingRandomFactors(claimParams)
 
-	tx, sigBytes, redeemScript, err := l.prepareSpendingTransaction(swapParams, claimParams, newAddr, 0, 0)
+	tx, sigBytes, redeemScript, err := l.prepareSpendingTransaction(swapParams, claimParams, newAddr, 0, fee)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -118,12 +142,33 @@ func (l *LiquidOnChain) CreatePreimageSpendingTransaction(swapParams *swap.Openi
 }
 
 func (l *LiquidOnChain) CreateCsvSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams) (txId, txHex, address string, error error) {
+	fee, err := l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindPreimageSpending, true)))
+	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	txId, txHex, newAddr, err := l.createCsvSpendingTransaction(swapParams, claimParams, fee)
+	if err == nil {
+		return txId, txHex, newAddr, nil
+	}
+	if !errors.Is(err, wallet.MinRelayFeeNotMetError) {
+		return "", "", "", err
+	}
+	fee, err = l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindPreimageSpending, false)))
+	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	return l.createCsvSpendingTransaction(swapParams, claimParams, fee)
+}
+
+func (l *LiquidOnChain) createCsvSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams, fee uint64) (txId, txHex, address string, error error) {
 	newAddr, err := l.liquidWallet.GetAddress()
 	if err != nil {
 		return "", "", "", err
 	}
 	l.AddBlindingRandomFactors(claimParams)
-	tx, sigBytes, redeemScript, err := l.prepareSpendingTransaction(swapParams, claimParams, newAddr, LiquidCsv, 0)
+	tx, sigBytes, redeemScript, err := l.prepareSpendingTransaction(swapParams, claimParams, newAddr, LiquidCsv, fee)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -140,11 +185,28 @@ func (l *LiquidOnChain) CreateCsvSpendingTransaction(swapParams *swap.OpeningPar
 }
 
 func (l *LiquidOnChain) CreateCoopSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams, takerSigner swap.Signer) (txId, txHex, address string, error error) {
-	refundAddr, err := l.NewAddress()
+	fee, err := l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindCoop, true)))
 	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	txId, txHex, newAddr, err := l.createCoopSpendingTransaction(swapParams, claimParams, takerSigner, fee)
+	if err == nil {
+		return txId, txHex, newAddr, nil
+	}
+	if !errors.Is(err, wallet.MinRelayFeeNotMetError) {
 		return "", "", "", err
 	}
-	refundFee, err := l.liquidWallet.GetFee(int64(l.getCoopClaimTxSize()))
+	fee, err = l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindCoop, false)))
+	if err != nil {
+		log.Infof("error getting fee %v", err)
+		fee = feeAmountPlaceholder
+	}
+	return l.createCoopSpendingTransaction(swapParams, claimParams, takerSigner, fee)
+}
+
+func (l *LiquidOnChain) createCoopSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams, takerSigner swap.Signer, fee uint64) (txId, txHex, address string, error error) {
+	refundAddr, err := l.NewAddress()
 	if err != nil {
 		return "", "", "", err
 	}
@@ -156,7 +218,7 @@ func (l *LiquidOnChain) CreateCoopSpendingTransaction(swapParams *swap.OpeningPa
 	if err != nil {
 		return "", "", "", err
 	}
-	spendingTx, sigHash, err := l.createSpendingTransaction(claimParams.OpeningTxHex, swapParams.Amount, 0, l.asset, redeemScript, refundAddr, refundFee, swapParams.BlindingKey, claimParams.EphemeralKey, claimParams.OutputAssetBlindingFactor, claimParams.BlindingSeed)
+	spendingTx, sigHash, err := l.createSpendingTransaction(claimParams.OpeningTxHex, swapParams.Amount, 0, l.asset, redeemScript, refundAddr, fee, swapParams.BlindingKey, claimParams.EphemeralKey, claimParams.OutputAssetBlindingFactor, claimParams.BlindingSeed)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -235,6 +297,9 @@ func (l *LiquidOnChain) prepareSpendingTransaction(swapParams *swap.OpeningParam
 
 // CreateSpendingTransaction returns the spendningTransaction for the swap
 func (l *LiquidOnChain) createSpendingTransaction(openingTxHex string, swapAmount uint64, csv uint32, asset, redeemScript []byte, redeemAddr string, preparedFee uint64, blindingKey, ephemeralPrivKey *btcec.PrivateKey, outputAbf, seed []byte) (tx *transaction.Transaction, sigHash [32]byte, err error) {
+	if preparedFee == 0 {
+		return nil, [32]byte{}, errors.New("fee must be set other than 0")
+	}
 	firstTx, err := transaction.NewTxFromHex(openingTxHex)
 	if err != nil {
 		log.Infof("error creating first tx %s, %v", openingTxHex, err)
@@ -263,16 +328,7 @@ func (l *LiquidOnChain) createSpendingTransaction(openingTxHex string, swapAmoun
 		return nil, [32]byte{}, errors.New(fmt.Sprintf("Tx value is not equal to the swap contract expected: %v, tx: %v", swapAmount, ubRes.Value))
 	}
 
-	feeAmountPlaceholder := uint64(500)
-	fee := preparedFee
-	if preparedFee == 0 {
-		fee, err = l.liquidWallet.GetFee(int64(l.getClaimTxSize()))
-		if err != nil {
-			fee = feeAmountPlaceholder
-		}
-	}
-
-	outputValue := ubRes.Value - fee
+	outputValue := ubRes.Value - preparedFee
 
 	finalVbfArgs := confidential.FinalValueBlindingFactorArgs{
 		InValues:      []uint64{ubRes.Value},
@@ -366,7 +422,7 @@ func (l *LiquidOnChain) createSpendingTransaction(openingTxHex string, swapAmoun
 	spendingTx.Outputs = append(spendingTx.Outputs, receiverOutput)
 
 	// add feeoutput
-	feeValue, _ := elementsutil.ValueToBytes(fee)
+	feeValue, _ := elementsutil.ValueToBytes(preparedFee)
 	feeScript := []byte{}
 	feeOutput := transaction.NewTxOutput(asset, feeValue, feeScript)
 	spendingTx.Outputs = append(spendingTx.Outputs, feeOutput)
@@ -378,12 +434,33 @@ func (l *LiquidOnChain) createSpendingTransaction(openingTxHex string, swapAmoun
 	return spendingTx, sigHash, nil
 }
 
-func (l *LiquidOnChain) getClaimTxSize() int {
-	return 1350
-}
+type transactionKind string
 
-func (l *LiquidOnChain) getCoopClaimTxSize() int {
-	return 1360
+const (
+	transactionKindPreimageSpending transactionKind = "preimage"
+	transactionKindCoop             transactionKind = "coop"
+	transactionKindOpening          transactionKind = "open"
+	transactionKindCSV              transactionKind = "csv"
+)
+
+func getEstimatedTxSize(t transactionKind, ctDiscount bool) int {
+	txsize := 0
+	switch t {
+	case transactionKindPreimageSpending:
+		txsize = 1350
+	case transactionKindCoop:
+		txsize = 1360
+	case transactionKindOpening:
+		txsize = EstimatedOpeningConfidentialTxSizeBytes
+	case transactionKindCSV:
+		txsize = 1350
+	default:
+		return 1360
+	}
+	if ctDiscount {
+		return txsize / 4
+	}
+	return txsize
 }
 
 func (l *LiquidOnChain) TxIdFromHex(txHex string) (string, error) {
@@ -529,12 +606,12 @@ func (l *LiquidOnChain) Blech32ToScript(blech32Addr string) ([]byte, error) {
 }
 
 func (l *LiquidOnChain) GetRefundFee() (uint64, error) {
-	return l.liquidWallet.GetFee(int64(l.getClaimTxSize()))
+	return l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindCoop, false)))
 }
 
 // GetFlatOpeningTXFee returns an estimate of the fee for the opening transaction.
 func (l *LiquidOnChain) GetFlatOpeningTXFee() (uint64, error) {
-	return l.liquidWallet.GetFee(EstimatedOpeningConfidentialTxSizeBytes)
+	return l.liquidWallet.GetFee(int64(getEstimatedTxSize(transactionKindOpening, true)))
 }
 
 func (l *LiquidOnChain) GetAsset() string {

--- a/test/lwk_cln_test.go
+++ b/test/lwk_cln_test.go
@@ -99,7 +99,7 @@ func Test_ClnCln_LWK_SwapIn(t *testing.T) {
 		bitcoind, liquidd, lightningds, scid, electrs, lwk := clnclnLWKSetup(t, uint64(math.Pow10(9)))
 		defer func() {
 			if t.Failed() {
-				filter := os.Getenv("PEERSWAP_TEST_FILTER")
+				filter := ""
 				pprintFail(
 					tailableProcess{
 						p:     bitcoind.DaemonProcess,

--- a/test/utils.go
+++ b/test/utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultLines = 30
+const defaultLines = 1000
 
 func IsIntegrationTest(t *testing.T) {
 	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {

--- a/testframework/elements.go
+++ b/testframework/elements.go
@@ -32,6 +32,11 @@ func getLiquiddConfig() map[string]string {
 		"initialfreecoins": "2100000000000000",
 		"validatepegin":    "0",
 		"chain":            "liquidregtest",
+		"acceptdiscountct": "1",
+		"creatediscountct": "1",
+		"minrelaytxfee":    "0.00000001",
+		"mintxfee":         "0.00000001",
+		"blockmintxfee":    "0.00000001",
 	}
 }
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	NotEnoughBalanceError = errors.New("Not enough balance on utxos")
+	NotEnoughBalanceError  = errors.New("Not enough balance on utxos")
+	MinRelayFeeNotMetError = errors.New("MinRelayFee not met")
 )
 
 const (


### PR DESCRIPTION
elements releases have the mempool policy patch.
To apply ct discount on peerswap, we uses an "Ask forgiveness not permission" approach, where we attempt to broadcast with the discounted fee, and if that fails, we retry with the non-discounted fee.

The discount is achieved by calculating the fee based on a discounted vsize(equivalent to 1/4 of the original tx size).

https://github.com/ElementsProject/elements/releases/tag/elements-23.2.2