### PR TITLE
clightning: liquid testnet port update

### DIFF
--- a/clightning/config.go
+++ b/clightning/config.go
@@ -591,7 +591,7 @@ func defaultBitcoinRpcPort(network string) uint {
 func defaultElementsRpcPort(network string) uint {
 	switch network {
 	case "liquidtestnet":
-		return 18891
+		return 7039
 	case "regtest":
 		return 18443
 	default:


### PR DESCRIPTION
The default port for the liquid testnet in elementsd has been changed from 18891 to 7039.

If the port is not specified, an error like `Could not connect to elements: Post "http://127.0.0.1:18891/wallet/\": EOF` will occur.

Change the default port for peerswap from 18891 to 7039 as well.