### PR TITLE
ci: update Nix installation and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Nix and run tests
-        uses: determinateSystems/nix-installer-action@v12
-      - uses: DeterminateSystems/magic-nix-cache-action@v7
-      - uses: DeterminateSystems/flake-checker-action@v8
+      - uses: nixbuild/nix-quick-install-action@v28
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v5
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          gc-max-store-size-linux: 1073741824
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: cache-${{ runner.os }}-
+          # created more than this number of seconds ago relative to the start of the `Post Restore` phase
+          purge-created: 0
+          # except the version with the `primary-key`, if it exists
+          purge-primary-key: never
       - run: nix-shell --run "make test-${{matrix.test-vector}}"


### PR DESCRIPTION
Introduces caching of the Nix store using `nix-community/cache-nix-action` to avoide rate limit errors and speed up subsequent CI runs.

The GitHub API rate limit was exceeded, resulting in a CI process that used to take about 30 minutes being shortened to about 5 minutes.