### PR TITLE
nix: update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711719691,
-        "narHash": "sha256-o/yHbl1XlgdhwBWCde6ch4OyJnI0qkBvXVEo0ZBerFc=",
+        "lastModified": 1725771415,
+        "narHash": "sha256-UzjfB9z3wDX91XTFo88J/s2qCzDKis7ZG+TmS2dYWOE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f54322490f509985fa8be4ac9304f368bd8ab924",
+        "rev": "fc13ad88bf7dbf2addb58f7e9d128c5547f59e93",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f54322490f509985fa8be4ac9304f368bd8ab924",
+        "rev": "fc13ad88bf7dbf2addb58f7e9d128c5547f59e93",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
   inputs = {
-    # Pinning to revision f54322490f509985fa8be4ac9304f368bd8ab924 
-    # - cln v24.02.1
-    # - lnd v0.17.4-beta
-    # - bitcoin v26.0
+    # Pinning to revision fc13ad88bf7dbf2addb58f7e9d128c5547f59e93 
+    # - cln v24.08
+    # - lnd v0.18.2-beta
+    # - bitcoin v27.1
     # - elements v23.2.1
-    nixpkgs.url = "github:NixOS/nixpkgs/f54322490f509985fa8be4ac9304f368bd8ab924";
+    nixpkgs.url = "github:NixOS/nixpkgs/fc13ad88bf7dbf2addb58f7e9d128c5547f59e93";
     flake-utils.url = "github:numtide/flake-utils";
     # blockstream-electrs: init at 0.4.1 #299761
     # https://github.com/NixOS/nixpkgs/pull/299761/commits/680d27ad847801af781e0a99e4b87ed73965c69a


### PR DESCRIPTION
Updates the following dependencies within flake.nix:

- cln to v24.08
- lnd to v0.18.2-beta
- bitcoin to v27.1
- elements to v23.2.1