### PR TITLE
swap: exclude non-active swap in csvPassedCallback

### DIFF
--- a/swap/service.go
+++ b/swap/service.go
@@ -348,6 +348,9 @@ func (s *SwapService) OnTxConfirmed(swapId string, txHex string, gotErr error) e
 // OnCsvPassed sends the csvpassed event to the corresponding swap
 func (s *SwapService) OnCsvPassed(swapId string) error {
 	swap, err := s.GetActiveSwap(swapId)
+	if errors.Is(err, ErrSwapDoesNotExist) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
csv wait list is always added in `AwaitPaymentOrCsvAction` state but removed only after csvPassedCallback.

`csvPassedCallback` always assumes an active swap, but in normal flows like preimage path, the swap might be complete,
leaving no active swap at this point.
This was not considered before, causing continuous errors.

Previously, if a swap was completed through means other than the `CSV path`, an error message `csv passed callback err: swap does not exist.` would occur unless the peerswap daemon was restarted.  
I have confirmed that this issue no longer occurs.