### PR TITLE
clightning: add shutdown hook for plugin

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -136,6 +136,7 @@ func NewClightningClient(ctx context.Context) (*ClightningClient, <-chan interfa
 		return nil, nil, err
 	}
 	cl.Plugin.SubscribeConnect(cl.OnConnect)
+	cl.Plugin.SubscribeShutdown(cl.OnShutdown)
 
 	cl.glightning = glightning.NewLightning()
 	cl.glightning.SetTimeout(40)
@@ -352,7 +353,7 @@ func (cl *ClightningClient) SetPeerswapConfig(config *Config) {
 		LiquidRpcHost:          config.Liquid.RpcHost,
 		LiquidRpcPort:          config.Liquid.RpcPort,
 		LiquidRpcWallet:        config.Liquid.RpcWallet,
-		LiquidSwaps:          *config.Liquid.LiquidSwaps,
+		LiquidSwaps:            *config.Liquid.LiquidSwaps,
 		PeerswapDir:            config.PeerswapDir,
 	}
 	if config.LWK != nil {
@@ -545,6 +546,10 @@ func (cl *ClightningClient) OnConnect(connectEvent *glightning.ConnectEvent) {
 			}
 		}
 	}()
+}
+
+func (cl *ClightningClient) OnShutdown() {
+	cl.Plugin.Stop()
 }
 
 // RegisterMethods registeres rpc methods to c-lightning

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
-	github.com/elementsproject/glightning v0.0.0-20240224063423-55240d61b52a
+	github.com/elementsproject/glightning v0.0.0-20240922021749-3b572176aa14
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/dvyukov/go-fuzz v0.0.0-20220726122315-1d375ef9f9f6 h1:sE4tvxWw01v7K3M
 github.com/dvyukov/go-fuzz v0.0.0-20220726122315-1d375ef9f9f6/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/elementsproject/glightning v0.0.0-20240224063423-55240d61b52a h1:xnVQmVqGmSs3m8zPQF4iYEYiUAmJx8MlT9vJ3lAaOjc=
 github.com/elementsproject/glightning v0.0.0-20240224063423-55240d61b52a/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
+github.com/elementsproject/glightning v0.0.0-20240922021749-3b572176aa14 h1:Q23txNJKtdTSXDoN4wF72bopQ0F0RyEkWL3nnoxfV/w=
+github.com/elementsproject/glightning v0.0.0-20240922021749-3b572176aa14/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
Introduces a shutdown hook to the clightning plugin, ensuring that the plugin is gracefully stopped when c-lightning shuts down.

* Subscribe to the 'shutdown' event.
* Updated glightning dependency t o include the 'shutdown' event. https://github.com/ElementsProject/glightning/pull/20

fixes: https://github.com/ElementsProject/peerswap/issues/307