### PR TITLE
golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,4 +101,8 @@ issues:
         - dupl
         - gosec
 run:
-  timeout: 5m
+  timeout: 1m
+  issues-exit-code: 1
+  tests: true
+  skip-dirs-use-default: true
+  allow-parallel-runners: true


### PR DESCRIPTION
Reduce the timeout for golangci-lint from 5 minutes to 1 minute.
Set issues-exit-code to 1 to ensure lint issues cause a non-zero exit.
Enable tests to be run during the linting process.
Use default directories for skipping.
Allow parallel runners to improve linting performance.