### PR TITLE
nixpkgs: Update to latest revision

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725771415,
-        "narHash": "sha256-UzjfB9z3wDX91XTFo88J/s2qCzDKis7ZG+TmS2dYWOE=",
+        "lastModified": 1731650604,
+        "narHash": "sha256-GZKb4C4BceEsApitbnFqyeKqjJpVDgSumi4LzVR9Iq4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc13ad88bf7dbf2addb58f7e9d128c5547f59e93",
+        "rev": "6915a163f351c32bd4557518d047725665e83d37",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc13ad88bf7dbf2addb58f7e9d128c5547f59e93",
+        "rev": "6915a163f351c32bd4557518d047725665e83d37",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
   inputs = {
-    # Pinning to revision fc13ad88bf7dbf2addb58f7e9d128c5547f59e93 
-    # - cln v24.08
-    # - lnd v0.18.2-beta
-    # - bitcoin v27.1
+    # Pinning to revision 6915a163f351c32bd4557518d047725665e83d37 
+    # - cln v24.08.02
+    # - lnd v0.18.3-beta
+    # - bitcoin v28.0
     # - elements v23.2.1
-    nixpkgs.url = "github:NixOS/nixpkgs/fc13ad88bf7dbf2addb58f7e9d128c5547f59e93";
+    nixpkgs.url = "github:NixOS/nixpkgs/6915a163f351c32bd4557518d047725665e83d37";
     flake-utils.url = "github:numtide/flake-utils";
     # blockstream-electrs: init at 0.4.1 #299761
     # https://github.com/NixOS/nixpkgs/pull/299761/commits/680d27ad847801af781e0a99e4b87ed73965c69a

--- a/testframework/elements.go
+++ b/testframework/elements.go
@@ -93,6 +93,8 @@ func NewBitcoinNode(testDir string, id int) (*BitcoinNode, error) {
 		"-txindex",
 		"-nowallet",
 		"-addresstype=bech32",
+		// https://github.com/lightningnetwork/lnd/issues/9163
+		"-deprecatedrpc=warnings",
 	}
 
 	bitcoinConfig := getBitcoindConfig()


### PR DESCRIPTION
Update nixpkgs to revision 6915a163f351c32bd4557518d047725665e83d37
- Update cln to v24.08.02
- Update lnd to v0.18.3-beta
- Update bitcoin to v28.0

> [!NOTE]
Only changes related to integration test code.