### PR TITLE
test: remove deprecated API allowance flag

### DIFF
--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -84,7 +84,6 @@ func NewCLightningNode(testDir string, bitcoin *BitcoinNode, id int) (*CLightnin
 		fmt.Sprintf("--bitcoin-rpcport=%s", bitcoinRpcPort),
 		fmt.Sprintf("--bitcoin-datadir=%s", bitcoin.DataDir),
 		fmt.Sprintf("--developer"),
-		fmt.Sprintf("--allow-deprecated-apis=true"),
 	}
 
 	// socketPath := filepath.Join(networkDir, "lightning-rpc")


### PR DESCRIPTION
Remove the '--allow-deprecated-apis=true' flag
from the CLightningNode initialization in the test framework.

This will increase the possibility of detecting problems before they occur, as support for the deprecated cln api is no longer available.