### PR TITLE
ci: update nix-flake schedule monthly[skip ci]

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -2,7 +2,7 @@ name: update-flake-lock
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 0 * * *' # runs daily at 00:00
+      - cron: '0 0 1 * *' # runs monthly on the 1st at 00:00
   push:
     branches:
       - master


### PR DESCRIPTION
Since the operation of https://github.com/ElementsProject/peerswap/pull/335 has been confirmed.
not affect the peerswap production codes.

> [!NOTE]  
> The changes are related to CI or productivity and do not affect the codebase's functionality.