### PR TITLE
peerswaprpc: typo. correct in gen_protos.sh

### DIFF
--- a/peerswaprpc/gen_protos.sh
+++ b/peerswaprpc/gen_protos.sh
@@ -13,4 +13,4 @@ protoc \
 	--openapiv2_out=. \
 	--openapiv2_opt logtostderr=true \
 	--openapiv2_opt grpc_api_configuration=peerswaprpc/peerswap.yaml \
-	peerswaprpc/peerswaprpc.protos
+	peerswaprpc/peerswaprpc.proto


### PR DESCRIPTION
> [!NOTE]
> No changes have been made to the function.