### PR TITLE
refine triggers

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,15 @@
+name: Buf
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [master]
+
+jobs:
+  buf-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,12 @@ on:
     branches:
       - master
   pull_request:
-    branches: [master]
+    types: [opened, synchronize, reopened]  
 
 env:
   SLOW_MACHINE: 1
 
 jobs:
-  buf:
-    runs-on: ubuntu-latest
-
-    steps:
-      # Run `git checkout`
-      - name: Checkout code
-        uses: actions/checkout@v4
-      # Run the `buf` CLI
-      - name: Buf Action
-        uses: bufbuild/buf-action@v1
-
   unit-tests:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Ensure the buf workflow includes labeled/unlabeled pull_request events so checks re-run on label changes, and separate Buf skip.

- Separate Buf checks into dedicated workflow
- Add labeled/unlabeled triggers to re-run checks