### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -237,13 +237,6 @@ func (cl *ClightningClient) getMaxHtlcAmtMsat(scid, nodeId string) (uint64, erro
 	return htlcMaximumMilliSatoshis, nil
 }
 
-func min(x, y uint64) uint64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // SpendableMsat returns an estimate of the total we could send through the
 // channel with given scid. Falls back to the owned amount in the channel.
 func (cl *ClightningClient) SpendableMsat(scid string) (uint64, error) {

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -100,13 +100,6 @@ func (l *Client) getMaxHtlcAmtMsat(chanId uint64, pubkey string) (uint64, error)
 	return maxHtlcAmtMsat, nil
 }
 
-func min(x, y uint64) uint64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // SpendableMsat returns an estimate of the total we could send through the
 // channel with given scid.
 func (l *Client) SpendableMsat(scid string) (uint64, error) {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.