### PR TITLE
refactor: use the built-in max/min

### DIFF
--- a/onchain/estimator.go
+++ b/onchain/estimator.go
@@ -297,10 +297,7 @@ func (m *minFeeManager) fetchMinFee() btcutil.Amount {
 	// By default, we'll use the backend node's minimum fee as the
 	// minimum fee rate we'll propose for transactions. However, if this
 	// happens to be lower than our fee floor, we'll enforce that instead.
-	m.minFeePerKW = newMinFee
-	if m.minFeePerKW < FeePerKwFloor {
-		m.minFeePerKW = FeePerKwFloor
-	}
+	m.minFeePerKW = max(newMinFee, FeePerKwFloor)
 	m.lastUpdatedTime = time.Now()
 
 	log.Debugf("Using minimum fee rate of %v sat/kw",

--- a/swap/fsm.go
+++ b/swap/fsm.go
@@ -268,10 +268,7 @@ func (s *SwapStateMachine) SendEvent(event EventType, eventCtx EventContext) (bo
 // exponentialBackoffAndJitter is function to wait for
 // exponential backoff and jitter.
 func (s *SwapStateMachine) exponentialBackoffAndJitter() {
-	temp := exponentialBackoffBase * int(math.Pow(2, float64(s.retries)))
-	if temp > exponentialBackoffCap {
-		temp = exponentialBackoffCap
-	}
+	temp := min(exponentialBackoffBase*int(math.Pow(2, float64(s.retries))), exponentialBackoffCap)
 	sleep := rand.Intn(temp)
 	time.Sleep(time.Duration(sleep) * time.Millisecond)
 }


### PR DESCRIPTION

Use the built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function to simplify the code.


Inspired by https://github.com/ElementsProject/peerswap/pull/367

