### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"time"
 
 	"github.com/elementsproject/glightning/glightning"
@@ -346,12 +347,7 @@ func (n *CLightningNode) OpenChannel(remote LightningNode, capacity, pushAmt uin
 			return false
 		}
 
-		for _, txId := range rawMempool {
-			if txId == fr.FundingTxId {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(rawMempool, fr.FundingTxId)
 	}, TIMEOUT)
 	if err != nil {
 		return "", fmt.Errorf("error waiting for tx in mempool: %w", err)

--- a/wallet/elementsrpcwallet.go
+++ b/wallet/elementsrpcwallet.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"strings"
 
@@ -129,11 +130,8 @@ func (r *ElementsRpcWallet) setupWallet() error {
 		return err
 	}
 	var walletLoaded bool
-	for _, v := range loadedWallets {
-		if v == r.walletName {
-			walletLoaded = true
-			break
-		}
+	if slices.Contains(loadedWallets, r.walletName) {
+		walletLoaded = true
 	}
 	if !walletLoaded {
 		_, err = r.rpcClient.LoadWallet(r.walletName, true)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.