### PR TITLE
Fix deprecated APIs handling and update glightning dependency

### DIFF
--- a/clightning/config.go
+++ b/clightning/config.go
@@ -124,7 +124,7 @@ func (c *ClnConfig) AllowDeprecatedAPIs() bool {
 // CheckForDeprecatedApiConfig tries to detect if allow-deprecated-apis is false
 // in the CLN config. If it is set false, we print a warning and exit because
 // deprecated CLN API fields might break PeerSwap.
-func CheckForDeprecatedApiConfig(client *ClightningClient) Processor {
+func CheckForDeprecatedApiConfig(client *ClightningClient, isDev bool) Processor {
 	return func(c *Config) (*Config, error) {
 		conf, err := client.glightning.ListConfigs()
 		if err != nil {
@@ -139,7 +139,7 @@ func CheckForDeprecatedApiConfig(client *ClightningClient) Processor {
 		if err != nil {
 			return nil, err
 		}
-		if !co.AllowDeprecatedAPIs() {
+		if !co.AllowDeprecatedAPIs() && !isDev {
 			log.Infof("WARNING: allow-deprecated-apis=false detected in CLN config. Exiting. More info: https://github.com/ElementsProject/peerswap/issues/232")
 			time.Sleep(1 * time.Second)
 			client.Plugin.Stop()
@@ -602,7 +602,7 @@ func ElementsCookieConnect() Processor {
 	}
 }
 
-func GetConfig(client *ClightningClient) (*Config, error) {
+func GetConfig(client *ClightningClient, isDev bool) (*Config, error) {
 	pl := &Pipeline{processors: []Processor{}}
 	pl = pl.
 		Add(SetWorkingDir()).
@@ -617,7 +617,7 @@ func GetConfig(client *ClightningClient) (*Config, error) {
 		Add(CheckBitcoinRpcIsUrl()).
 		Add(BitcoinCookieConnect()).
 		Add(ElementsCookieConnect()).
-		Add(CheckForDeprecatedApiConfig(client))
+		Add(CheckForDeprecatedApiConfig(client, isDev))
 
 	return pl.Run()
 }

--- a/cmd/peerswap-plugin/main.go
+++ b/cmd/peerswap-plugin/main.go
@@ -129,7 +129,7 @@ func run(ctx context.Context, lightningPlugin *clightning.ClightningClient) erro
 	}
 	log.Infof("Using data dir: %s", dataDir)
 
-	config, err := clightning.GetConfig(lightningPlugin)
+	config, err := clightning.GetConfig(lightningPlugin, isdev.IsDev())
 	if err != nil {
 		log.Infof("Could not read config: %s", err.Error())
 		return err

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
-	github.com/elementsproject/glightning v0.0.0-20250204171900-f3064a110c6b
+	github.com/elementsproject/glightning v0.0.0-20250728212555-da2a093f26a9
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,10 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/elementsproject/glightning v0.0.0-20250204171900-f3064a110c6b h1:PnXI3HU7C+5zEOiSzooB8tNeZB1dnbJWfPN4Vy1EUrM=
-github.com/elementsproject/glightning v0.0.0-20250204171900-f3064a110c6b/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
+github.com/elementsproject/glightning v0.0.0-20250725080149-0bc2f7d7f7e6 h1:2z8VScIJjMjsnsHgX+0DRA69rzKDMJFoHpwz4fuHAbc=
+github.com/elementsproject/glightning v0.0.0-20250725080149-0bc2f7d7f7e6/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
+github.com/elementsproject/glightning v0.0.0-20250728212555-da2a093f26a9 h1:Nbo9FQdKfabpAbTM68TiofzGbJI6EKrqZ6kQ2YLcvdI=
+github.com/elementsproject/glightning v0.0.0-20250728212555-da2a093f26a9/go.mod h1:YAdIeSyx8VEhDCtEaGOJLmWNpPaQ3x4vYSAj9Vrppdo=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/testframework/clightning.go
+++ b/testframework/clightning.go
@@ -81,7 +81,6 @@ func NewCLightningNode(testDir string, bitcoin *BitcoinNode, id int) (*CLightnin
 		fmt.Sprintf("--bitcoin-rpcport=%s", bitcoinRpcPort),
 		fmt.Sprintf("--bitcoin-datadir=%s", bitcoin.DataDir),
 		fmt.Sprintf("--developer"),
-		fmt.Sprintf("--allow-deprecated-apis=true"),
 	}
 
 	// Check socket path length before proceeding


### PR DESCRIPTION
Remove the '--allow-deprecated-apis=true' flag
from the CLightningNode initialization in the test framework.

This will increase the possibility of detecting problems before they occur, as support for the deprecated cln api is no longer available.

Fixes https://github.com/ElementsProject/peerswap/issues/232