### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/lwk/config_test.go
+++ b/lwk/config_test.go
@@ -27,7 +27,6 @@ func TestNewlwkNetwork(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := lwk.NewlwkNetwork(tt.network)
@@ -62,7 +61,6 @@ func TestLWKURL(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := lwk.NewLWKURL(tt.endpoint)
@@ -98,7 +96,6 @@ func TestElectrsURL(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := lwk.NewElectrsURL(tt.endpoint)

--- a/messages/types_test.go
+++ b/messages/types_test.go
@@ -21,7 +21,6 @@ func TestPeerswapCustomMessageType(t *testing.T) {
 		"invalid":             {msgType: "invalid", wantErr: true},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := PeerswapCustomMessageType(tt.msgType)

--- a/swap/actions_test.go
+++ b/swap/actions_test.go
@@ -63,7 +63,6 @@ func TestCheckPremiumAmount_Execute(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := v.Execute(nil, tt.swap)

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -92,7 +92,6 @@ func Test_Wumbo(t *testing.T) {
 
 	for _, tt := range tests {
 		// Rebind for parallel tests.
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.