### PR TITLE
refactor: replace the deprecated function in the ioutil package

### DIFF
--- a/clightning/config.go
+++ b/clightning/config.go
@@ -3,7 +3,6 @@ package clightning
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -186,7 +185,7 @@ func CheckForLegacyClnConfig(plugin *glightning.Plugin) Processor {
 // in the running CLN container.
 func ReadFromFile() Processor {
 	return func(c *Config) (*Config, error) {
-		data, err := ioutil.ReadFile(filepath.Join(c.PeerswapDir, defaultConfigFileName))
+		data, err := os.ReadFile(filepath.Join(c.PeerswapDir, defaultConfigFileName))
 		if os.IsNotExist(err) {
 			return c, nil
 		}

--- a/clightning/config_test.go
+++ b/clightning/config_test.go
@@ -2,7 +2,7 @@ package clightning
 
 import (
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ func Test_ReadFromFile(t *testing.T) {
 
 	dir := t.TempDir()
 	fp := filepath.Join(dir, "peerswap.conf")
-	_ = ioutil.WriteFile(fp, []byte(conf), fs.ModePerm)
+	_ = os.WriteFile(fp, []byte(conf), fs.ModePerm)
 
 	c := &Config{PeerswapDir: dir, Bitcoin: &BitcoinConf{}, Liquid: &LiquidConf{}}
 	actual, err := ReadFromFile()(c)
@@ -68,7 +68,7 @@ func Test_ReadFromFile(t *testing.T) {
 func Test_ReadFromFile_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	fp := filepath.Join(dir, "peerswap.conf")
-	_ = ioutil.WriteFile(fp, []byte{}, fs.ModePerm)
+	_ = os.WriteFile(fp, []byte{}, fs.ModePerm)
 
 	c := &Config{PeerswapDir: dir, Bitcoin: &BitcoinConf{}, Liquid: &LiquidConf{}}
 	actual, err := ReadFromFile()(c)

--- a/cmd/peerswaplnd/config.go
+++ b/cmd/peerswaplnd/config.go
@@ -3,7 +3,6 @@ package peerswaplnd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,7 +122,7 @@ func (o *OnchainConfig) Validate() error {
 			return errors.New("rpcpass or rpcpasswordfile must be set")
 		}
 		if o.RpcPasswordFile != "" {
-			passBytes, err := ioutil.ReadFile(o.RpcPasswordFile)
+			passBytes, err := os.ReadFile(o.RpcPasswordFile)
 			if err != nil {
 				return err
 			}

--- a/lnd/connect.go
+++ b/lnd/connect.go
@@ -2,7 +2,7 @@ package lnd
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/elementsproject/peerswap/cmd/peerswaplnd"
@@ -86,7 +86,7 @@ func GetClientConnection(ctx context.Context, cfg *peerswaplnd.LndConfig) (*grpc
 	if err != nil {
 		return nil, err
 	}
-	macBytes, err := ioutil.ReadFile(cfg.MacaroonPath)
+	macBytes, err := os.ReadFile(cfg.MacaroonPath)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func getClientConnectionForTests(ctx context.Context, cfg *peerswaplnd.LndConfig
 	if err != nil {
 		return nil, err
 	}
-	macBytes, err := ioutil.ReadFile(cfg.MacaroonPath)
+	macBytes, err := os.ReadFile(cfg.MacaroonPath)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -160,7 +159,7 @@ func Test_AddRemovePeer_Runtime(t *testing.T) {
 	err = policy.AddToSuspiciousPeerList(pubkeys[1])
 	assert.NoError(t, err)
 
-	policyFile, err := ioutil.ReadFile(policyFilePath)
+	policyFile, err := os.ReadFile(policyFilePath)
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
@@ -178,7 +177,7 @@ func Test_AddRemovePeer_Runtime(t *testing.T) {
 	err = policy.RemoveFromSuspiciousPeerList(pubkeys[1])
 	assert.NoError(t, err)
 
-	policyFile, err = ioutil.ReadFile(policyFilePath)
+	policyFile, err = os.ReadFile(policyFilePath)
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
@@ -351,7 +350,7 @@ func Test_AllowSwapRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, policy.NewSwapsAllowed())
 
-	policyFile, _ := ioutil.ReadFile(policyFilePath)
+	policyFile, _ := os.ReadFile(policyFilePath)
 	assert.Equal(
 		t,
 		"allow_new_swaps=false\n",
@@ -362,7 +361,7 @@ func Test_AllowSwapRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, policy.NewSwapsAllowed())
 
-	policyFile, _ = ioutil.ReadFile(policyFilePath)
+	policyFile, _ = os.ReadFile(policyFilePath)
 	assert.Equal(
 		t,
 		"allow_new_swaps=true\n",

--- a/testframework/proxy.go
+++ b/testframework/proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -201,7 +200,7 @@ func NewLndRpcClient(host, certPath, macaroonPath string, options ...grpc.DialOp
 		return nil, fmt.Errorf("NewClientTLSFromFile() %w", err)
 	}
 
-	macBytes, err := ioutil.ReadFile(macaroonPath)
+	macBytes, err := os.ReadFile(macaroonPath)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFile() %w", err)
 	}


### PR DESCRIPTION
Starting from Go 1.16, some functions in the ioutil package have been deprecated. The Go team recommends quickly switching to methods from the os or io packages instead. 

More info can see: https://github.com/golang/go/issues/45557