### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,15 +9,15 @@ var (
 )
 
 type PeerswapLogger interface {
-	Infof(format string, v ...interface{})
-	Debugf(format string, v ...interface{})
+	Infof(format string, v ...any)
+	Debugf(format string, v ...any)
 }
 
 func SetLogger(peerswapLogger PeerswapLogger) {
 	logger = peerswapLogger
 }
 
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	if logger != nil {
 		logger.Infof(format, v...)
 	} else {
@@ -25,7 +25,7 @@ func Infof(format string, v ...interface{}) {
 	}
 }
 
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	if logger != nil {
 		logger.Debugf(format, v...)
 	} else {

--- a/timer/service.go
+++ b/timer/service.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type CallbackFactory func(...interface{}) func()
+type CallbackFactory func(...any) func()
 
 type TimeOutService struct {
 	CallbackFactory CallbackFactory
@@ -15,6 +15,6 @@ func NewTimeOutService(cbf CallbackFactory) *TimeOutService {
 	return &TimeOutService{CallbackFactory: cbf}
 }
 
-func (s *TimeOutService) AddNewTimeOut(ctx context.Context, d time.Duration, args ...interface{}) {
+func (s *TimeOutService) AddNewTimeOut(ctx context.Context, d time.Duration, args ...any) {
 	go TimedCallback(ctx, d, s.CallbackFactory(args))
 }


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.