### PR TITLE
refactor: drop legacy // +build comment

### DIFF
--- a/isdev/fasttests.go
+++ b/isdev/fasttests.go
@@ -1,5 +1,4 @@
 //go:build fast_test
-// +build fast_test
 
 package isdev
 

--- a/isdev/isdev.go
+++ b/isdev/isdev.go
@@ -1,5 +1,4 @@
 //go:build dev
-// +build dev
 
 package isdev
 

--- a/isdev/isnotdev.go
+++ b/isdev/isnotdev.go
@@ -1,5 +1,4 @@
 //go:build !dev
-// +build !dev
 
 package isdev
 

--- a/isdev/nofasttests.go
+++ b/isdev/nofasttests.go
@@ -1,5 +1,4 @@
 //go:build !fast_test
-// +build !fast_test
 
 package isdev
 

--- a/lnd/lnd_test.go
+++ b/lnd/lnd_test.go
@@ -1,5 +1,4 @@
 //go:build misc
-// +build misc
 
 package lnd
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,5 +1,4 @@
 //go:build docker
-// +build docker
 
 package wallet
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild