### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/clightning/clightning.go
+++ b/clightning/clightning.go
@@ -83,7 +83,7 @@ type ClightningClient struct {
 
 	msgHandlers     []func(peerId string, messageType string, payload []byte) error
 	paymenthandlers []func(swapId string, invoiceType swap.InvoiceType)
-	initChan        chan interface{}
+	initChan        chan any
 	nodeId          string
 	hexToIdMap      map[string]string
 
@@ -134,7 +134,7 @@ func (cl *ClightningClient) AddPaymentNotifier(swapId string, payreq string, inv
 }
 
 // NewClightningClient returns a new clightning cl and channel which get closed when the Plugin is initialized
-func NewClightningClient(ctx context.Context) (*ClightningClient, <-chan interface{}, error) {
+func NewClightningClient(ctx context.Context) (*ClightningClient, <-chan any, error) {
 	cl := &ClightningClient{ctx: ctx}
 	cl.Plugin = glightning.NewPlugin(cl.onInit)
 	err := cl.Plugin.RegisterHooks(&glightning.Hooks{
@@ -154,7 +154,7 @@ func NewClightningClient(ctx context.Context) (*ClightningClient, <-chan interfa
 	//b = b.Exp(big.NewInt(2), big.NewInt(featureBit), nil)
 	//cl.Plugin.AddNodeFeatures(b.Bytes())
 	cl.Plugin.SetDynamic(true)
-	cl.initChan = make(chan interface{})
+	cl.initChan = make(chan any)
 	cl.hexToIdMap = make(map[string]string)
 	return cl, cl.initChan, nil
 }
@@ -685,10 +685,10 @@ func NewGlightninglogger(plugin *glightning.Plugin) *Glightninglogger {
 	return &Glightninglogger{plugin: plugin}
 }
 
-func (g *Glightninglogger) Infof(format string, v ...interface{}) {
+func (g *Glightninglogger) Infof(format string, v ...any) {
 	g.plugin.Log(fmt.Sprintf(format, v...), glightning.Info)
 }
 
-func (g *Glightninglogger) Debugf(format string, v ...interface{}) {
+func (g *Glightninglogger) Debugf(format string, v ...any) {
 	g.plugin.Log(fmt.Sprintf(format, v...), glightning.Debug)
 }

--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -34,7 +34,7 @@ type LiquidGetAddress struct {
 	cl *ClightningClient `json:"-"`
 }
 
-func (g *LiquidGetAddress) New() interface{} {
+func (g *LiquidGetAddress) New() any {
 	return &LiquidGetAddress{
 		cl: g.cl,
 	}
@@ -83,7 +83,7 @@ func (g *LiquidGetBalance) Name() string {
 	return "peerswap-lbtc-getbalance"
 }
 
-func (g *LiquidGetBalance) New() interface{} {
+func (g *LiquidGetBalance) New() any {
 	return &LiquidGetBalance{
 		cl: g.cl,
 	}
@@ -131,7 +131,7 @@ func (s *LiquidSendToAddress) Name() string {
 	return "peerswap-lbtc-sendtoaddress"
 }
 
-func (s *LiquidSendToAddress) New() interface{} {
+func (s *LiquidSendToAddress) New() any {
 	return &LiquidSendToAddress{
 		cl: s.cl,
 	}
@@ -183,7 +183,7 @@ type SwapOut struct {
 	cl                  *ClightningClient `json:"-"`
 }
 
-func (l *SwapOut) New() interface{} {
+func (l *SwapOut) New() any {
 	return &SwapOut{
 		cl: l.cl,
 	}
@@ -305,7 +305,7 @@ type SwapIn struct {
 	cl                  *ClightningClient `json:"-"`
 }
 
-func (l *SwapIn) New() interface{} {
+func (l *SwapIn) New() any {
 	return &SwapIn{
 		cl: l.cl,
 	}
@@ -419,7 +419,7 @@ type ListSwaps struct {
 	cl            *ClightningClient `json:"-"`
 }
 
-func (l *ListSwaps) New() interface{} {
+func (l *ListSwaps) New() any {
 	return &ListSwaps{
 		cl: l.cl,
 	}
@@ -484,7 +484,7 @@ func (l *ListNodes) LongDescription() string {
 	return ""
 }
 
-func (l *ListNodes) New() interface{} {
+func (l *ListNodes) New() any {
 	return &ListNodes{
 		cl: l.cl,
 	}
@@ -536,7 +536,7 @@ func (l *ListPeers) LongDescription() string {
 	return ""
 }
 
-func (l *ListPeers) New() interface{} {
+func (l *ListPeers) New() any {
 	return &ListPeers{
 		cl: l.cl,
 	}
@@ -627,7 +627,7 @@ func (g *GetSwap) Name() string {
 	return "peerswap-getswap"
 }
 
-func (g *GetSwap) New() interface{} {
+func (g *GetSwap) New() any {
 	return &GetSwap{
 		cl:     g.cl,
 		SwapId: g.SwapId,
@@ -682,7 +682,7 @@ func (c ReloadPolicyFile) Name() string {
 	return "peerswap-reloadpolicy"
 }
 
-func (c ReloadPolicyFile) New() interface{} {
+func (c ReloadPolicyFile) New() any {
 	return c
 }
 
@@ -727,7 +727,7 @@ func (c GetRequestedSwaps) Name() string {
 	return "peerswap-listswaprequests"
 }
 
-func (c GetRequestedSwaps) New() interface{} {
+func (c GetRequestedSwaps) New() any {
 	return c
 }
 
@@ -766,7 +766,7 @@ func (g *ListActiveSwaps) Name() string {
 	return "peerswap-listactiveswaps"
 }
 
-func (g *ListActiveSwaps) New() interface{} {
+func (g *ListActiveSwaps) New() any {
 	return &ListActiveSwaps{
 		cl: g.cl,
 	}
@@ -813,7 +813,7 @@ func (g *AllowSwapRequests) Name() string {
 	return "peerswap-allowswaprequests"
 }
 
-func (g *AllowSwapRequests) New() interface{} {
+func (g *AllowSwapRequests) New() any {
 	return &AllowSwapRequests{
 		cl:                      g.cl,
 		AllowSwapRequestsString: g.AllowSwapRequestsString,
@@ -863,7 +863,7 @@ func (g *AddPeer) Name() string {
 	return "peerswap-addpeer"
 }
 
-func (g *AddPeer) New() interface{} {
+func (g *AddPeer) New() any {
 	return &AddPeer{
 		cl:         g.cl,
 		PeerPubkey: g.PeerPubkey,
@@ -906,7 +906,7 @@ func (g *RemovePeer) Name() string {
 	return "peerswap-removepeer"
 }
 
-func (g *RemovePeer) New() interface{} {
+func (g *RemovePeer) New() any {
 	return &RemovePeer{
 		cl:         g.cl,
 		PeerPubkey: g.PeerPubkey,
@@ -949,7 +949,7 @@ func (g *AddSuspiciousPeer) Name() string {
 	return "peerswap-addsuspeer"
 }
 
-func (g *AddSuspiciousPeer) New() interface{} {
+func (g *AddSuspiciousPeer) New() any {
 	return &AddSuspiciousPeer{
 		cl:         g.cl,
 		PeerPubkey: g.PeerPubkey,
@@ -993,7 +993,7 @@ func (g *RemoveSuspiciousPeer) Name() string {
 	return "peerswap-removesuspeer"
 }
 
-func (g *RemoveSuspiciousPeer) New() interface{} {
+func (g *RemoveSuspiciousPeer) New() any {
 	return &RemoveSuspiciousPeer{
 		cl:         g.cl,
 		PeerPubkey: g.PeerPubkey,
@@ -1037,7 +1037,7 @@ func (c *ListConfig) Name() string {
 	return "peerswap-listconfig"
 }
 
-func (c *ListConfig) New() interface{} {
+func (c *ListConfig) New() any {
 	return &ListConfig{
 		cl: c.cl,
 	}
@@ -1098,7 +1098,7 @@ func (c *GetPremiumRate) Name() string {
 	return "peerswap-getpremiumrate"
 }
 
-func (c *GetPremiumRate) New() interface{} {
+func (c *GetPremiumRate) New() any {
 	return &GetPremiumRate{
 		cl: c.cl,
 	}
@@ -1146,7 +1146,7 @@ func (c *UpdatePremiumRate) Name() string {
 	return "peerswap-updatepremiumrate"
 }
 
-func (c *UpdatePremiumRate) New() interface{} {
+func (c *UpdatePremiumRate) New() any {
 	return &UpdatePremiumRate{
 		cl: c.cl,
 	}
@@ -1200,7 +1200,7 @@ func (c *DeletePremiumRate) Name() string {
 	return "peerswap-deletepremiumrate"
 }
 
-func (c *DeletePremiumRate) New() interface{} {
+func (c *DeletePremiumRate) New() any {
 	return &DeletePremiumRate{
 		cl: c.cl,
 	}
@@ -1250,7 +1250,7 @@ func (c *UpdateGlobalPremiumRate) Name() string {
 	return "peerswap-updateglobalpremiumrate"
 }
 
-func (c *UpdateGlobalPremiumRate) New() interface{} {
+func (c *UpdateGlobalPremiumRate) New() any {
 	return &UpdateGlobalPremiumRate{
 		cl: c.cl,
 	}
@@ -1303,7 +1303,7 @@ func (c *GetGlobalPremiumRate) Name() string {
 	return "peerswap-getglobalpremiumrate"
 }
 
-func (c *GetGlobalPremiumRate) New() interface{} {
+func (c *GetGlobalPremiumRate) New() any {
 	return &GetGlobalPremiumRate{
 		cl: c.cl,
 	}

--- a/clightning/config.go
+++ b/clightning/config.go
@@ -344,9 +344,9 @@ type ParsedClnConfig struct {
 }
 
 type PluginConfig struct {
-	Path    string                 `json:"path"`
-	Name    string                 `json:"name"`
-	Options map[string]interface{} `json:"options"`
+	Path    string         `json:"path"`
+	Name    string         `json:"name"`
+	Options map[string]any `json:"options"`
 }
 
 type ConfigEntry struct {
@@ -378,7 +378,7 @@ func isBitcoinConfigEmpty(bitcoin *BitcoinConf) bool {
 		bitcoin.RpcPasswordFile == "" && bitcoin.RpcHost == "" && bitcoin.RpcPort == 0
 }
 
-func parseClnConfig(conf interface{}) (*ParsedClnConfig, error) {
+func parseClnConfig(conf any) (*ParsedClnConfig, error) {
 	data, err := json.Marshal(conf)
 	if err != nil {
 		return nil, err
@@ -425,7 +425,7 @@ func applyPluginConfig(c *Config, plugins []*PluginConfig) {
 	}
 }
 
-func applyBcliOptions(c *Config, options map[string]interface{}) {
+func applyBcliOptions(c *Config, options map[string]any) {
 	if v, ok := options["bitcoin-datadir"]; ok {
 		c.Bitcoin.DataDir = toString(v)
 	}
@@ -443,14 +443,14 @@ func applyBcliOptions(c *Config, options map[string]interface{}) {
 	}
 }
 
-func toString(v interface{}) string {
+func toString(v any) string {
 	if str, ok := v.(string); ok {
 		return str
 	}
 	return ""
 }
 
-func toUint(v interface{}) uint {
+func toUint(v any) uint {
 	switch val := v.(type) {
 	case string:
 		port, err := strconv.Atoi(val)

--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -611,11 +611,11 @@ func NewLndLogger(cfg *peerswaplnd.PeerSwapConfig) (*LndLogger, func() error, er
 	return &LndLogger{loglevel: cfg.LogLevel}, logFile.Close, nil
 }
 
-func (l *LndLogger) Infof(format string, v ...interface{}) {
+func (l *LndLogger) Infof(format string, v ...any) {
 	core_log.Printf("[INFO] "+format, v...)
 }
 
-func (l *LndLogger) Debugf(format string, v ...interface{}) {
+func (l *LndLogger) Debugf(format string, v ...any) {
 	if l.loglevel == peerswaplnd.LOGLEVEL_DEBUG {
 		core_log.Printf("[DEBUG] "+format, v...)
 	}

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -41,7 +41,7 @@ type Client struct {
 	cc  *grpc.ClientConn
 	ctx context.Context
 
-	invoiceSubscriptions map[string]interface{}
+	invoiceSubscriptions map[string]any
 	pubkey               string
 
 	sync.Mutex
@@ -72,7 +72,7 @@ func NewClient(
 		cc:                   cc,
 		ctx:                  ctx,
 		pubkey:               gi.IdentityPubkey,
-		invoiceSubscriptions: make(map[string]interface{}),
+		invoiceSubscriptions: make(map[string]any),
 	}, nil
 }
 

--- a/lwk/client.go
+++ b/lwk/client.go
@@ -25,7 +25,7 @@ func NewLwk(endpoint string) *lwkclient {
 	}
 }
 
-func (l *lwkclient) request(ctx context.Context, m jrpc2.Method, resp interface{}) error {
+func (l *lwkclient) request(ctx context.Context, m jrpc2.Method, resp any) error {
 	id := l.api.nextID()
 	mr := &jrpc2.Request{Id: id, Method: m}
 	jbytes, err := json.Marshal(mr)

--- a/peersync/lightning_adapter_test.go
+++ b/peersync/lightning_adapter_test.go
@@ -68,11 +68,11 @@ func (m *mockCustomMessageStream) Context() context.Context {
 	return m.ctx
 }
 
-func (m *mockCustomMessageStream) SendMsg(interface{}) error {
+func (m *mockCustomMessageStream) SendMsg(any) error {
 	return nil
 }
 
-func (m *mockCustomMessageStream) RecvMsg(interface{}) error {
+func (m *mockCustomMessageStream) RecvMsg(any) error {
 	return nil
 }
 

--- a/swap/fsm.go
+++ b/swap/fsm.go
@@ -383,7 +383,7 @@ func (s *SwapStateMachine) printFeeInvoiceInfo() {
 	s.Infof("Paid Feeinvoice of %v sats", paidAmt)
 }
 
-func (s *SwapStateMachine) Infof(format string, v ...interface{}) {
+func (s *SwapStateMachine) Infof(format string, v ...any) {
 	idString := fmt.Sprintf("%s", s.SwapId.String())
 	log.Infof("[Swap:"+idString+"] "+format, v...)
 }

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -61,7 +61,7 @@ func Test_RestoreFromPassedCSV(t *testing.T) {
 	// Do swap.
 	go func() {
 		// We need to run this in a go routine as the Request call is blocking and sometimes does not return.
-		var response map[string]interface{}
+		var response map[string]any
 		if err := lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -200,7 +200,7 @@ func Test_Recover_PassedSwap_BTC(t *testing.T) {
 	// Do swap.
 	go func() {
 		// We need to run this in a go routine as the Request call is blocking and sometimes does not return.
-		var response map[string]interface{}
+		var response map[string]any
 		if err := lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -312,7 +312,7 @@ func Test_Recover_PassedSwap_LBTC(t *testing.T) {
 	// Do swap.
 	go func() {
 		// We need to run this in a go routine as the Request call is blocking and sometimes does not return.
-		var response map[string]interface{}
+		var response map[string]any
 		if err := lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,

--- a/test/setup.go
+++ b/test/setup.go
@@ -69,7 +69,7 @@ func makeTestDataDir(t *testing.T) string {
 	return tempDir
 }
 
-func mustToml(tb testing.TB, v interface{}) []byte {
+func mustToml(tb testing.TB, v any) []byte {
 	tb.Helper()
 
 	data, err := toml.Marshal(v)
@@ -275,7 +275,7 @@ func clnclnElementsSetup(
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
 
-	var result interface{}
+	var result any
 	requireNoError(t, lightningds[0].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 	requireNoError(t, lightningds[1].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 
@@ -579,7 +579,7 @@ func clnclnLWKSetup(t *testing.T, fundAmt uint64) (
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
 
-	var result interface{}
+	var result any
 	requireNoError(t, lightningds[0].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 	requireNoError(t, lightningds[1].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 
@@ -949,7 +949,7 @@ func clnclnLWKLiquidSetup(t *testing.T, fundAmt uint64) (
 		t.Fatalf("lightingds[0].OpenChannel() %v", err)
 	}
 
-	var result interface{}
+	var result any
 	requireNoError(t, lightningds[0].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 	requireNoError(t, lightningds[1].Rpc.Request(&clightning.ReloadPolicyFile{}, &result))
 

--- a/test/swap_bitcoin_test.go
+++ b/test/swap_bitcoin_test.go
@@ -72,7 +72,7 @@ func startClnSwap(t *testing.T, params *testParams) {
 			t.Fatalf("maker node is not a CLightningNode")
 		}
 		go func(node *testframework.CLightningNode) {
-			var response map[string]interface{}
+			var response map[string]any
 			_ = node.Rpc.Request(&clightning.SwapIn{
 				SatAmt:              params.swapAmt,
 				ShortChannelId:      params.scid,
@@ -86,7 +86,7 @@ func startClnSwap(t *testing.T, params *testParams) {
 			t.Fatalf("taker node is not a CLightningNode")
 		}
 		go func(node *testframework.CLightningNode) {
-			var response map[string]interface{}
+			var response map[string]any
 			_ = node.Rpc.Request(&clightning.SwapOut{
 				SatAmt:              params.swapAmt,
 				ShortChannelId:      params.scid,
@@ -216,7 +216,7 @@ func Test_OnlyOneActiveSwapPerChannelCln(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			var response map[string]interface{}
+			var response map[string]any
 			err := lightningds[0].Rpc.Request(&clightning.SwapOut{
 				SatAmt:              params.swapAmt,
 				ShortChannelId:      params.scid,
@@ -256,7 +256,7 @@ func Test_ClnCln_ExcessiveAmount(t *testing.T) {
 		asset := "btc"
 
 		// Swap out should fail as the swap_amt is to high.
-		var response map[string]interface{}
+		var response map[string]any
 		err := lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -291,7 +291,7 @@ func Test_Cln_HtlcMaximum(t *testing.T) {
 		_, err := lightningds[0].SetHtlcMaximumMilliSatoshis(scid, params.origTakerBalance*1000/2-1)
 		assertNoError(t, err)
 
-		var response map[string]interface{}
+		var response map[string]any
 		err = lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -312,7 +312,7 @@ func Test_Cln_HtlcMaximum(t *testing.T) {
 		_, err := lightningds[0].SetHtlcMaximumMilliSatoshis(scid, params.origTakerBalance*1000/2-1)
 		assertNoError(t, err)
 
-		var response map[string]interface{}
+		var response map[string]any
 		err = lightningds[1].Rpc.Request(&clightning.SwapIn{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -339,7 +339,7 @@ func Test_Cln_Premium(t *testing.T) {
 		DumpOnFailure(t, WithBitcoin(bitcoind), WithCLightnings(lightningds))
 
 		var premiumRatePPM int64 = -10000
-		var premiumRes interface{}
+		var premiumRes any
 		err := lightningds[0].Rpc.Request(&clightning.UpdatePremiumRate{
 			PeerID:         lightningds[1].Id(),
 			Asset:          premium.BTC.String(),
@@ -352,7 +352,7 @@ func Test_Cln_Premium(t *testing.T) {
 		params.swapInPremiumRate = premiumRatePPM
 		asset := "btc"
 
-		var response map[string]interface{}
+		var response map[string]any
 		err = lightningds[1].Rpc.Request(&clightning.SwapIn{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -376,7 +376,7 @@ func Test_Cln_Premium(t *testing.T) {
 		DumpOnFailure(t, WithBitcoin(bitcoind), WithCLightnings(lightningds))
 
 		var premiumRatePPM int64 = -10000
-		var premiumRes interface{}
+		var premiumRes any
 		err := lightningds[1].Rpc.Request(&clightning.UpdatePremiumRate{
 			PeerID:         lightningds[0].Id(),
 			Asset:          premium.BTC.String(),
@@ -389,7 +389,7 @@ func Test_Cln_Premium(t *testing.T) {
 		params.swapOutPremiumRate = premiumRatePPM
 		asset := "btc"
 
-		var response map[string]interface{}
+		var response map[string]any
 		err = lightningds[0].Rpc.Request(&clightning.SwapOut{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -411,7 +411,7 @@ func Test_Cln_Premium(t *testing.T) {
 		params.premiumLimitRatePPM = -1
 		asset := "btc"
 
-		var response map[string]interface{}
+		var response map[string]any
 		err := lightningds[1].Rpc.Request(&clightning.SwapIn{
 			SatAmt:              params.swapAmt,
 			ShortChannelId:      params.scid,
@@ -446,7 +446,7 @@ func Test_ClnCln_StuckChannels(t *testing.T) {
 		return lightningds[1].IsChannelActive(scid)
 	}, testframework.TIMEOUT))
 
-	var response map[string]interface{}
+	var response map[string]any
 	err := lightningds[1].Rpc.Request(
 		&clightning.SwapIn{
 			SatAmt:         100,
@@ -482,7 +482,7 @@ func Test_ClnCln_Poll(t *testing.T) {
 	// Ensure that the poll executed at the start of peerswap succeeds
 	require.Error(lightningds[0].WaitForLog("failed to send custom message", 20*time.Second))
 	for _, lightningd := range lightningds {
-		var result interface{}
+		var result any
 		err := lightningd.Rpc.Request(&clightning.ReloadPolicyFile{}, &result)
 		if err != nil {
 			t.Fatal(err)

--- a/test/swap_liquid_test.go
+++ b/test/swap_liquid_test.go
@@ -71,7 +71,7 @@ func startLiquidSwap(t *testing.T, params *testParams) {
 		)
 
 		var (
-			response map[string]interface{}
+			response map[string]any
 			err      error
 		)
 

--- a/test/swap_lwk_test.go
+++ b/test/swap_lwk_test.go
@@ -39,7 +39,7 @@ func startClnLwkSwap(t *testing.T, params *testParams, checkResp bool) {
 			t.Fatalf("maker node is not a CLightningNodeWithLiquid")
 		}
 		go func(node *CLightningNodeWithLiquid) {
-			var response map[string]interface{}
+			var response map[string]any
 			err := node.Rpc.Request(&clightning.SwapIn{
 				SatAmt:              params.swapAmt,
 				ShortChannelId:      params.scid,
@@ -56,7 +56,7 @@ func startClnLwkSwap(t *testing.T, params *testParams, checkResp bool) {
 			t.Fatalf("taker node is not a CLightningNodeWithLiquid")
 		}
 		go func(node *CLightningNodeWithLiquid) {
-			var response map[string]interface{}
+			var response map[string]any
 			err := node.Rpc.Request(&clightning.SwapOut{
 				SatAmt:              params.swapAmt,
 				ShortChannelId:      params.scid,
@@ -202,7 +202,7 @@ func Test_ClnCln_LWKLiquid_BackendDown(t *testing.T) {
 				lwk.Process.Kill()
 			},
 			request: func(node *CLightningNodeWithLiquid, params *testParams) error {
-				var response map[string]interface{}
+				var response map[string]any
 				return node.Rpc.Request(
 					&clightning.SwapOut{
 						SatAmt:              params.swapAmt,
@@ -220,7 +220,7 @@ func Test_ClnCln_LWKLiquid_BackendDown(t *testing.T) {
 				electrs.Process.Kill()
 			},
 			request: func(node *CLightningNodeWithLiquid, params *testParams) error {
-				var response map[string]interface{}
+				var response map[string]any
 				return node.Rpc.Request(
 					&clightning.SwapOut{
 						SatAmt:         params.swapAmt,

--- a/test/utils.go
+++ b/test/utils.go
@@ -107,7 +107,7 @@ func (n *clnPollableNode) ID() string {
 }
 
 func (n *clnPollableNode) TriggerPoll() error {
-	var result interface{}
+	var result any
 	err := n.Rpc.Request(&clightning.ReloadPolicyFile{}, &result)
 	if err != nil {
 		return err

--- a/test/wumbo_test.go
+++ b/test/wumbo_test.go
@@ -113,7 +113,7 @@ func Test_Wumbo(t *testing.T) {
 			// Ensure BTC premiums are zero for this test. Defaults for swap_out are non-zero (2000 ppm).
 			// Use the global premium setter to avoid peer-specific state.
 			for _, ln := range lightningds {
-				var _resp map[string]interface{}
+				var _resp map[string]any
 				// Set BTC SWAP_OUT premium to 0 ppm.
 				err := ln.Rpc.Request(
 					&clightning.UpdateGlobalPremiumRate{
@@ -170,7 +170,7 @@ func Test_Wumbo(t *testing.T) {
 					premiumLimitRatePPM: int64(tt.swapAmtSat / 10),
 				}
 
-				var response map[string]interface{}
+				var response map[string]any
 				err = lightningds[0].Rpc.Request(
 					&clightning.SwapOut{
 						SatAmt:              params.swapAmt,
@@ -200,7 +200,7 @@ func Test_Wumbo(t *testing.T) {
 					premiumLimitRatePPM: int64(tt.swapAmtSat / 10),
 				}
 
-				var response map[string]interface{}
+				var response map[string]any
 				err = lightningds[1].Rpc.Request(
 					&clightning.SwapIn{
 						SatAmt:              params.swapAmt,

--- a/testframework/proxy.go
+++ b/testframework/proxy.go
@@ -154,7 +154,7 @@ func NewRpcProxy(configFile string) (*RpcProxy, error) {
 	}, nil
 }
 
-func (p *RpcProxy) Call(method string, parameters ...interface{}) (*jsonrpc.RPCResponse, error) {
+func (p *RpcProxy) Call(method string, parameters ...any) (*jsonrpc.RPCResponse, error) {
 	return p.Rpc.Call(method, parameters...)
 }
 


### PR DESCRIPTION
Inspired by https://github.com/ElementsProject/peerswap/pull/407 and replace all.

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.