### PR TITLE
multi: adapt fee floor to bitcoind version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
 {
     "name": "peerswap",
     "image": "ghcr.io/xtruder/nix-devcontainer:v1",
+    "runArgs": [
+        "--platform=linux/amd64"
+    ],
     "onCreateCommand": "nix-env -iA cachix -f https://cachix.org/api/v1/install && cachix use peerswap && nix develop --command echo 'Nix environment ready'",
     "postCreateCommand": "sudo chmod a+w /usr/local/bin/ && nix develop --command bash -c 'GOBIN=/usr/local/bin go install github.com/bufbuild/buf/cmd/buf@v1.50.0'",
     "customizations": {
@@ -12,7 +15,8 @@
                 "jnoortheen.nix-ide",
                 "mkhl.direnv",
                 "golang.go",
-                "bufbuild.vscode-buf"
+                "bufbuild.vscode-buf",
+                "openai.chatgpt"
             ]
         }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,18 +1,41 @@
 {
   "nodes": {
-    "crane": {
+    "blockstream-electrs": {
       "inputs": {
+        "crane": [
+          "crane"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
-          "lwk-flake",
           "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1713979152,
-        "narHash": "sha256-apdecPuh8SOQnkEET/kW/UcfjCRb8JbV5BKjoH+DcP4=",
+        "lastModified": 1764596662,
+        "narHash": "sha256-2z/cZcCg62tAd/a3qIVuiPZYruFQk7SwQYPTD5CnPek=",
+        "owner": "Blockstream",
+        "repo": "electrs",
+        "rev": "e60ca890959b2cb9b62d5253ffa0cf4b25b144eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Blockstream",
+        "repo": "electrs",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a5eca68a2cf11adb32787fc141cddd29ac8eb79c",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
         "type": "github"
       },
       "original": {
@@ -74,7 +97,9 @@
     },
     "lwk-flake": {
       "inputs": {
-        "crane": "crane",
+        "crane": [
+          "crane"
+        ],
         "electrs-flake": "electrs-flake",
         "flake-utils": [
           "flake-utils"
@@ -83,7 +108,9 @@
           "nixpkgs"
         ],
         "registry-flake": "registry-flake",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": [
+          "rust-overlay"
+        ]
       },
       "locked": {
         "lastModified": 1728894785,
@@ -102,33 +129,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751285371,
-        "narHash": "sha256-/hDU+2AUeFFu5qGHO/UyFMc4UG/x5Cw5uXO36KGTk6c=",
+        "lastModified": 1765457389,
+        "narHash": "sha256-ddhDtNYvleZeYF7g7TRFSmuQuZh7HCgqstg5YBGwo5s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9c03fbbaf84d85bb28eee530c7e9edc4021ca1b",
+        "rev": "f997fa0f94fb1ce55bccb97f60d41412ae8fde4c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs2": {
-      "locked": {
-        "lastModified": 1711632680,
-        "narHash": "sha256-JSC40xJKTVMQCf5jGCGvi0xGjF0sdaXIMwzxrvZZbjI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "680d27ad847801af781e0a99e4b87ed73965c69a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "680d27ad847801af781e0a99e4b87ed73965c69a",
         "type": "github"
       }
     },
@@ -168,29 +179,26 @@
     },
     "root": {
       "inputs": {
+        "blockstream-electrs": "blockstream-electrs",
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "lwk-flake": "lwk-flake",
         "nixpkgs": "nixpkgs",
-        "nixpkgs2": "nixpkgs2"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "lwk-flake",
-          "flake-utils"
-        ],
         "nixpkgs": [
-          "lwk-flake",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1714356894,
-        "narHash": "sha256-W6Mss7AG6bnFT1BqRApHXvLXBrFOu7V0+EUe9iML30s=",
+        "lastModified": 1765680428,
+        "narHash": "sha256-fyPmRof9SZeI14ChPk5rVPOm7ISiiGkwGCunkhM+eUg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d9b44509b4064f0a3fc9c7c92a603861f52fbedc",
+        "rev": "eb3898d8ef143d4bf0f7f2229105fc51c7731b2f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,55 +1,97 @@
 {
   inputs = {
+    # Base packages for devShell.
+    # nixpkgs is pinned via `flake.lock` (currently rev f997fa0f94fb1ce55bccb97f60d41412ae8fde4c).
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    # blockstream-electrs: init at 0.4.1 #299761
-    # https://github.com/NixOS/nixpkgs/pull/299761/commits/680d27ad847801af781e0a99e4b87ed73965c69a
-    nixpkgs2.url = "github:NixOS/nixpkgs/680d27ad847801af781e0a99e4b87ed73965c69a";
-    # lwk: init at 9ddd20a806625bb40cd063ad61d80d106809a9fd
-    # https://github.com/Blockstream/lwk/commit/9ddd20a806625bb40cd063ad61d80d106809a9fd
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+    blockstream-electrs = {
+      url = "github:Blockstream/electrs";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        rust-overlay.follows = "rust-overlay";
+        crane.follows = "crane";
+      };
+    };
+
     lwk-flake = {
       url = "github:blockstream/lwk/9ddd20a806625bb40cd063ad61d80d106809a9fd";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
+        crane.follows = "crane";
+        rust-overlay.follows = "rust-overlay";
       };
     };
   };
-  outputs = { self, nixpkgs, nixpkgs2, flake-utils, lwk-flake }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = import nixpkgs {
-            system = system;
-          };
-          pkgs2 = import nixpkgs2 {
-            system = system;
-          };
-          blockstream-electrs = pkgs2.blockstream-electrs.overrideAttrs (oldAttrs: {
-            cargoBuildFlags = [ "--features liquid" "--bin electrs" ];
-          });
-          bitcoind = pkgs.bitcoind.overrideAttrs (attrs: {
-            meta = attrs.meta or { } // { priority = 0; };
-          });
-          lwk = lwk-flake.packages.${system}.bin;
-        in
-        with pkgs;
-        {
-          devShells.default = mkShell {
-            buildInputs = [
-              go_1_23        # Go 1.23.10 (updated from nixpkgs-unstable)
-              gotools        # Go development tools
-              blockstream-electrs  # Electrum Rust Server 0.4.1
-              bitcoind       # Bitcoin Core daemon v29.0.0 (updated from v28.0.0)
-              elementsd      # Elements daemon v23.2.4 (Liquid)
-              clightning     # Core Lightning v25.05 (updated from v24.11)
-              lnd           # Lightning Network Daemon 0.19.1-beta (updated from 0.18.3-beta)
-              lwk           # Liquid Wallet Kit 0.8.0
-            ];
-            # Cannot run the debugger without this
-            # see https://github.com/go-delve/delve/issues/3085
-            hardeningDisable = [ "all" ];
-          };
-        }
-      );
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      lwk-flake,
+      blockstream-electrs,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          system = system;
+        };
+
+        # Liquid-capable electrs build (from the Blockstream electrs flake input).
+        # Version check (inside `nix develop`): `electrs --version`
+        electrs-liquid = blockstream-electrs.packages.${system}.binLiquid;
+
+        # Liquid Wallet Kit CLI (pinned to the commit in `inputs.lwk-flake.url`).
+        # Version check (inside `nix develop`): `lwk --version`
+        lwk = lwk-flake.packages.${system}.bin;
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell {
+          buildInputs = [
+            # Go toolchain (go 1.25.4; build/test). Version check: `go version`
+            go
+            # Go tooling bundle (gotools 0.34.0; e.g. `gopls`, `goimports`). Version checks:
+            # - `gopls version`
+            # - `goimports -h` (prints usage; some builds don't support `--version`)
+            gotools
+
+            # Liquid indexer (electrs 0.4.1; used by dev/test flows that need Liquid chain data).
+            electrs-liquid
+
+            # Bitcoin/Elements daemons (used by integration tests / local networks).
+            # Version checks:
+            # - `bitcoind --version` (bitcoind 30.0)
+            # - `elementsd --version` (elementsd 23.2.4)
+            bitcoind
+            elementsd
+
+            # Lightning implementations (used by integration tests / local setups).
+            # Version checks:
+            # - `lightningd --version` (Core Lightning / clightning 25.09.2)
+            # - `lnd --version` (lnd 0.19.3-beta)
+            clightning
+            lnd
+
+            # Wallet / Liquid tooling (lwk_cli 0.8.0).
+            lwk
+          ];
+
+          hardeningDisable = [ "all" ];
+        };
+      }
+    );
 }

--- a/lnd/lnd_test.go
+++ b/lnd/lnd_test.go
@@ -169,7 +169,12 @@ func Test_LndSystemsPreimage(t *testing.T) {
 	address := fmt.Sprintf("localhost:%v", 10101+1*100)
 
 	lndFeeEstimator := NewLndFeeEstimator(ctx, walletrpc.NewWalletKitClient(lndConn))
-	btcOnchain := onchain.NewBitcoinOnChain(lndFeeEstimator, &chaincfg.RegressionNetParams)
+	btcOnchain := onchain.NewBitcoinOnChain(
+		lndFeeEstimator,
+		onchain.LegacyFeeFloorSatPerKw,
+		onchain.LegacyFeeFloorSatPerKw,
+		&chaincfg.RegressionNetParams,
+	)
 
 	swapLnd, err := NewLnd(ctx, tlsCertPath, macaroonPath, address, btcOnchain)
 	if err != nil {
@@ -275,7 +280,12 @@ func Test_LndSystemsCsv(t *testing.T) {
 	address := fmt.Sprintf("localhost:%v", 10101+1*100)
 
 	lndFeeEstimator := NewLndFeeEstimator(ctx, walletrpc.NewWalletKitClient(lndConn))
-	btcOnchain := onchain.NewBitcoinOnChain(lndFeeEstimator, &chaincfg.RegressionNetParams)
+	btcOnchain := onchain.NewBitcoinOnChain(
+		lndFeeEstimator,
+		onchain.LegacyFeeFloorSatPerKw,
+		onchain.LegacyFeeFloorSatPerKw,
+		&chaincfg.RegressionNetParams,
+	)
 
 	swapLnd, err := NewLnd(ctx, tlsCertPath, macaroonPath, address, btcOnchain)
 	if err != nil {

--- a/lnd/txwatcher_test.go
+++ b/lnd/txwatcher_test.go
@@ -42,32 +42,24 @@ func TestTxWatcher_GetBlockHeight(t *testing.T) {
 		t.Fatalf("Could not create tx watcher: %v", err)
 	}
 
-	// We expect a block height of 101 as this is how we setup a bitcoind and
-	// lnd setup on startup.
-	err = testframework.WaitFor(func() bool {
-		bh, err := txwatcher.GetBlockHeight()
-		if err != nil {
-			t.Fatalf("Failed GetBlockHeight(): %v", err)
-		}
-		return bh == 101
-	}, 50*time.Second)
+	initial, err := txwatcher.GetBlockHeight()
 	if err != nil {
-		t.Fatalf("Failed waiting for block height of 101: %v", err)
+		t.Fatalf("Failed GetBlockHeight(): %v", err)
 	}
 
 	// Mine one more block
 	bitcoind.GenerateBlocks(1)
 
-	// We now expect a block height of 102.
+	expected := initial + 1
 	err = testframework.WaitFor(func() bool {
 		bh, err := txwatcher.GetBlockHeight()
 		if err != nil {
 			t.Fatalf("Failed GetBlockHeight(): %v", err)
 		}
-		return bh == 102
+		return bh == expected
 	}, 50*time.Second)
 	if err != nil {
-		t.Fatalf("Failed waiting for block height of 102: %v", err)
+		t.Fatalf("Failed waiting for block height of %d: %v", expected, err)
 	}
 }
 

--- a/onchain/bitcoin_test.go
+++ b/onchain/bitcoin_test.go
@@ -13,9 +13,11 @@ func TestBitcoinOnChain_GetFee_UseFallbackFeeRate(t *testing.T) {
 
 	estimator := &EstimatorMock{}
 	fallbackFeeRate := btcutil.Amount(300)
+	feeFloor := btcutil.Amount(100)
 	btcOnChain := NewBitcoinOnChain(
 		estimator,
 		fallbackFeeRate,
+		feeFloor,
 		&chaincfg.Params{},
 	)
 
@@ -48,9 +50,11 @@ func TestBitcoinOnChain_GetFee_UseFloorFeeRate(t *testing.T) {
 	estimator := &EstimatorMock{}
 	// Set fallback below floor so that floor is used
 	fallbackFeeRate := btcutil.Amount(200)
+	feeFloor := btcutil.Amount(275)
 	btcOnChain := NewBitcoinOnChain(
 		estimator,
 		fallbackFeeRate,
+		feeFloor,
 		&chaincfg.Params{},
 	)
 

--- a/onchain/estimator_test.go
+++ b/onchain/estimator_test.go
@@ -18,7 +18,8 @@ func TestGBitcoin_Estimator(t *testing.T) {
 	feeEstimator, err := NewGBitcoindEstimator(
 		gbitcoinBackend,
 		"ECONOMICAL",
-		FeePerKwFloor,
+		LegacyFeeFloorSatPerKw,
+		LegacyFeeFloorSatPerKw,
 	)
 	require.NoError(t, err)
 
@@ -34,14 +35,15 @@ func TestGBitcoin_Estimator(t *testing.T) {
 	// Check that min fee manager is set. mempoolMinFee should be in sat/kw
 	mempoolMinFeeSatPerKb, _ := btcutil.NewAmount(mempoolMinFeeBTCPerKb)
 	mempoolMinFeeSatPerKw := mempoolMinFeeSatPerKb / 4
-	require.Equal(t, mempoolMinFeeSatPerKw, feeEstimator.minFeeManager.minFeePerKW)
+	require.Less(t, mempoolMinFeeSatPerKw, LegacyFeeFloorSatPerKw)
+	require.Equal(t, LegacyFeeFloorSatPerKw, feeEstimator.minFeeManager.minFeePerKW)
 
 	// Check that fallback fee is returned if the feeEstimator returns an error
 	efe := fmt.Errorf("some error")
 	gbitcoinBackend.EstimateFeeError = &efe
 	fee, err := feeEstimator.EstimateFeePerKW(10)
 	require.NoError(t, err)
-	require.Equal(t, FeePerKwFloor, fee)
+	require.Equal(t, LegacyFeeFloorSatPerKw, fee)
 
 	// Check that fee is converted correctly
 	feeRateBTCPerKb := 0.00023

--- a/onchain/fee_floor.go
+++ b/onchain/fee_floor.go
@@ -1,0 +1,77 @@
+package onchain
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/btcsuite/btcd/btcutil"
+)
+
+const (
+	modernFeeFloorMajor = 29
+	modernFeeFloorMinor = 2
+
+	// LegacyFeeFloorSatPerKw enforces ~1 sat/vB minimums for older nodes.
+	LegacyFeeFloorSatPerKw btcutil.Amount = 253
+	// ModernFeeFloorSatPerKw matches the v29.2+ mempoolminfee default (0.1 sat/vB).
+	ModernFeeFloorSatPerKw btcutil.Amount = 25
+)
+
+var bitcoinVersionPattern = regexp.MustCompile(`(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
+
+// DetermineFeeFloor inspects the provided Bitcoin Core version string (as
+// returned by getnetworkinfo subversion) and picks the default fee floor. It
+// returns both the chosen floor and the normalized semantic version string.
+func DetermineFeeFloor(versionString string) (btcutil.Amount, string) {
+	version := normalizeBitcoinVersion(versionString)
+	if version == nil {
+		return LegacyFeeFloorSatPerKw, ""
+	}
+
+	if version.major > modernFeeFloorMajor || (version.major == modernFeeFloorMajor && version.minor >= modernFeeFloorMinor) {
+		return ModernFeeFloorSatPerKw, version.String()
+	}
+
+	return LegacyFeeFloorSatPerKw, version.String()
+}
+
+type bitcoinVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func (v *bitcoinVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+func normalizeBitcoinVersion(input string) *bitcoinVersion {
+	matches := bitcoinVersionPattern.FindStringSubmatch(input)
+	if matches == nil {
+		return nil
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil
+	}
+
+	minor := parseVersionSegment(matches, 2)
+	patch := parseVersionSegment(matches, 3)
+
+	return &bitcoinVersion{major: major, minor: minor, patch: patch}
+}
+
+func parseVersionSegment(matches []string, idx int) int {
+	if len(matches) <= idx || matches[idx] == "" {
+		return 0
+	}
+
+	value, err := strconv.Atoi(matches[idx])
+	if err != nil {
+		return 0
+	}
+
+	return value
+}

--- a/onchain/fee_floor_test.go
+++ b/onchain/fee_floor_test.go
@@ -1,0 +1,51 @@
+package onchain
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDetermineFeeFloor(t *testing.T) {
+	tcs := []struct {
+		name           string
+		input          string
+		wantFloor      btcutil.Amount
+		wantNormalized string
+	}{
+		{
+			name:           "modern version",
+			input:          "/Satoshi:29.2.0/",
+			wantFloor:      ModernFeeFloorSatPerKw,
+			wantNormalized: "29.2.0",
+		},
+		{
+			name:           "legacy version",
+			input:          "/Satoshi:29.1.1/",
+			wantFloor:      LegacyFeeFloorSatPerKw,
+			wantNormalized: "29.1.1",
+		},
+		{
+			name:           "unknown input",
+			input:          "custom",
+			wantFloor:      LegacyFeeFloorSatPerKw,
+			wantNormalized: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotFloor, gotNormalized := DetermineFeeFloor(tc.input)
+
+			if diff := cmp.Diff(tc.wantFloor, gotFloor); diff != "" {
+				t.Errorf("fee floor mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantNormalized, gotNormalized); diff != "" {
+				t.Errorf("normalized version mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/bitcoin_fee_floor_test.go
+++ b/test/bitcoin_fee_floor_test.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/elementsproject/peerswap/onchain"
+	"github.com/elementsproject/peerswap/testframework"
+)
+
+func TestBitcoinFeeFloorMatchesNodeVersion(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	builder := NewHarnessBuilder(t)
+	bitcoind := builder.Bitcoind()
+	builder.EnsureBitcoindStarted()
+
+	var networkInfo struct {
+		Subversion string `json:"subversion"`
+	}
+	r, err := bitcoind.Call("getnetworkinfo")
+	requireNoError(t, err)
+	requireNoError(t, r.GetObject(&networkInfo))
+	requireNew(t).NotEmpty(networkInfo.Subversion, "bitcoind subversion should be present")
+
+	expectedFloor, normalizedVersion := onchain.DetermineFeeFloor(networkInfo.Subversion)
+	requireNew(t).NotEmpty(normalizedVersion, "bitcoind version should be parseable")
+
+	cln := builder.AddCLightningNode(1,
+		WithClnExtraArgs("--dev-bitcoind-poll=1", "--dev-fast-gossip", "--large-channels"),
+	)
+
+	builder.Start()
+
+	pattern := fmt.Sprintf(
+		"Detected Bitcoin Core version %s, using fee floor %d sat/kw",
+		regexp.QuoteMeta(normalizedVersion),
+		expectedFloor,
+	)
+	err = cln.WaitForLog(pattern, testframework.TIMEOUT)
+	requireNoError(t, err, "peerswap should log fee floor derived from bitcoind version")
+}


### PR DESCRIPTION
Introduces dynamic detection of the Bitcoin Core fee floor
based on the connected backend version. Previously, PeerSwap enforced
a hardcoded floor of 253 sat/kw (approx. 1 sat/vB).

With Bitcoin Core v29.2 lowering the default minimum relay fee, this
change allows PeerSwap to utilize cheaper fee rates when supported.

Added DetermineFeeFloor to select between legacy (253 sat/kw)
and modern (25 sat/kw) floors based on version parsing.

https://github.com/ElementsProject/peerswap/issues/404