### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/peerswaprpc/paging.go
+++ b/peerswaprpc/paging.go
@@ -41,10 +41,7 @@ func pagingBounds(total int, pageSize uint32, pageToken string, unpagedIfEmpty b
 		start = total
 	}
 
-	end = start + size
-	if end > total {
-		end = total
-	}
+	end = min(start+size, total)
 
 	if end < total {
 		nextPageToken = strconv.Itoa(end)


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.