### PR TITLE
multi: add premium rate sanity check warnings

### DIFF
--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -1161,6 +1161,9 @@ func (c *UpdatePremiumRate) Call() (jrpc2.Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating premium rate: %v", err)
 	}
+	if err := c.cl.ps.ValidateRate(c.PeerID, rate); err != nil {
+		log.Infof("Premium rate warning: %v", err)
+	}
 	err = c.cl.ps.SetRate(context.Background(), c.PeerID, rate)
 	if err != nil {
 		return nil, fmt.Errorf("error setting premium rate: %v", err)
@@ -1264,6 +1267,9 @@ func (c *UpdateGlobalPremiumRate) Call() (jrpc2.Result, error) {
 		toPremiumOperationType(c.Operation), premium.NewPPM(c.PremiumRatePPM))
 	if err != nil {
 		return nil, fmt.Errorf("error creating premium rate: %v", err)
+	}
+	if err := c.cl.ps.ValidateDefaultRate(rate); err != nil {
+		log.Infof("Premium rate warning: %v", err)
 	}
 	err = c.cl.ps.SetDefaultRate(context.Background(), rate)
 	if err != nil {

--- a/peerswaprpc/server.go
+++ b/peerswaprpc/server.go
@@ -625,6 +625,9 @@ func (p *PeerswapServer) UpdateGlobalPremiumRate(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("could not create rate: %v", err)
 	}
+	if err := p.ps.ValidateDefaultRate(rate); err != nil {
+		log.Infof("Premium rate warning: %v", err)
+	}
 	err = p.ps.SetDefaultRate(ctx, rate)
 	if err != nil {
 		return nil, fmt.Errorf("could not set default rate: %v", err)
@@ -666,6 +669,9 @@ func (p *PeerswapServer) UpdatePremiumRate(ctx context.Context,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create rate: %v", err)
+	}
+	if err := p.ps.ValidateRate(request.GetNodeId(), rate); err != nil {
+		log.Infof("Premium rate warning: %v", err)
 	}
 	err = p.ps.SetRate(ctx, request.GetNodeId(), rate)
 	if err != nil {

--- a/premium/validate.go
+++ b/premium/validate.go
@@ -1,0 +1,123 @@
+package premium
+
+import "fmt"
+
+// ValidateRate checks that the given rate does not work against the node
+// operator's interest, using stored rates for the peer (falling back to
+// defaults) for cross-rate checks.
+func (p *Setting) ValidateRate(peerID string, rate *PremiumRate) error {
+	lookup := func(asset AssetType, op OperationType) int64 {
+		r, err := p.GetRate(peerID, asset, op)
+		if err != nil {
+			return 0
+		}
+		return r.PremiumRatePPM().Value()
+	}
+	return validateRate(rate, lookup)
+}
+
+// ValidateDefaultRate is like ValidateRate but uses only default rates
+// for cross-rate checks.
+func (p *Setting) ValidateDefaultRate(rate *PremiumRate) error {
+	lookup := func(asset AssetType, op OperationType) int64 {
+		r, err := p.GetDefaultRate(asset, op)
+		if err != nil {
+			return 0
+		}
+		return r.PremiumRatePPM().Value()
+	}
+	return validateRate(rate, lookup)
+}
+
+// validateRate runs checks in priority order and returns the first violation.
+func validateRate(
+	rate *PremiumRate,
+	lookupRate func(AssetType, OperationType) int64,
+) error {
+	ppm := rate.PremiumRatePPM().Value()
+	asset := rate.Asset()
+	op := rate.Operation()
+
+	if err := checkSignConvention(asset, op, ppm); err != nil {
+		return err
+	}
+	if err := checkSameAssetSum(asset, op, ppm, lookupRate); err != nil {
+		return err
+	}
+
+	// TODO: check BTC_SWAP_IN + LBTC_SWAP_OUT against external Boltz
+	// peg-out rate when available (see #394 check 3)
+
+	return checkCrossAssetSum(asset, op, ppm, lookupRate)
+}
+
+// checkSignConvention rejects SWAP_IN > 0 and SWAP_OUT < 0.
+func checkSignConvention(
+	asset AssetType, op OperationType, ppm int64,
+) error {
+	if op == SwapIn && ppm > 0 {
+		return fmt.Errorf(
+			"cannot set %s %s rate to %d ppm: positive rate means "+
+				"you are paying peers to swap in -- expected negative or zero",
+			asset, op, ppm)
+	}
+	if op == SwapOut && ppm < 0 {
+		return fmt.Errorf(
+			"cannot set %s %s rate to %d ppm: negative rate means "+
+				"you are paying peers to swap out -- expected positive or zero",
+			asset, op, ppm)
+	}
+	return nil
+}
+
+// checkSameAssetSum rejects SWAP_IN + SWAP_OUT <= 0 for the same asset.
+func checkSameAssetSum(
+	asset AssetType, op OperationType, ppm int64,
+	lookupRate func(AssetType, OperationType) int64,
+) error {
+	complementOp := SwapOut
+	if op == SwapOut {
+		complementOp = SwapIn
+	}
+	sameAssetSum := ppm + lookupRate(asset, complementOp)
+	if sameAssetSum <= 0 {
+		return fmt.Errorf(
+			"cannot set %s %s rate to %d ppm: %s_SWAP_IN + %s_SWAP_OUT = %d "+
+				"(must be > 0) -- peers can profit by doing SWAP_OUT then SWAP_IN; "+
+				"hint: if adjusting both rates, increase the SWAP_OUT rate first, "+
+				"then decrease the SWAP_IN rate, to avoid temporarily "+
+				"triggering this check",
+			asset, op, ppm, asset, asset, sameAssetSum)
+	}
+	return nil
+}
+
+// checkCrossAssetSum rejects LBTC_SWAP_IN + BTC_SWAP_OUT <= 0.
+func checkCrossAssetSum(
+	asset AssetType, op OperationType, ppm int64,
+	lookupRate func(AssetType, OperationType) int64,
+) error {
+	if asset == LBTC && op == SwapIn {
+		crossSum := ppm + lookupRate(BTC, SwapOut)
+		if crossSum <= 0 {
+			return fmt.Errorf(
+				"cannot set %s %s rate to %d ppm: "+
+					"LBTC_SWAP_IN + BTC_SWAP_OUT = %d (must be > 0) -- "+
+					"peers can profit by doing BTC swap-out, "+
+					"free peg-in, then LBTC swap-in",
+				asset, op, ppm, crossSum)
+		}
+	}
+	if asset == BTC && op == SwapOut {
+		crossSum := lookupRate(LBTC, SwapIn) + ppm
+		if crossSum <= 0 {
+			return fmt.Errorf(
+				"cannot set %s %s rate to %d ppm: "+
+					"LBTC_SWAP_IN + BTC_SWAP_OUT = %d (must be > 0) -- "+
+					"peers can profit by doing BTC swap-out, "+
+					"free peg-in, then LBTC swap-in",
+				asset, op, ppm, crossSum)
+		}
+	}
+	return nil
+}

--- a/premium/validate_test.go
+++ b/premium/validate_test.go
@@ -1,0 +1,279 @@
+package premium_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elementsproject/peerswap/premium"
+	"github.com/samber/lo"
+)
+
+func Test_ValidateRate_SignConvention(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		asset       premium.AssetType
+		operation   premium.OperationType
+		ppm         int64
+		complement  int64
+		wantErr     bool
+		wantContain string
+	}{
+		"BTC SwapIn negative ok": {
+			premium.BTC, premium.SwapIn, -500, 1000, false, "",
+		},
+		"BTC SwapIn zero ok": {
+			premium.BTC, premium.SwapIn, 0, 1000, false, "",
+		},
+		"BTC SwapIn positive bad": {
+			premium.BTC, premium.SwapIn, 500, 1000, true,
+			"cannot set BTC SWAP_IN rate to 500 ppm",
+		},
+		"BTC SwapIn boundary +1 bad": {
+			premium.BTC, premium.SwapIn, 1, 1000, true,
+			"cannot set BTC SWAP_IN rate to 1 ppm",
+		},
+		"BTC SwapOut positive ok": {
+			premium.BTC, premium.SwapOut, 500, 0, false, "",
+		},
+		"BTC SwapOut negative bad": {
+			premium.BTC, premium.SwapOut, -500, 0, true,
+			"cannot set BTC SWAP_OUT rate to -500 ppm",
+		},
+		"BTC SwapOut boundary -1 bad": {
+			premium.BTC, premium.SwapOut, -1, 0, true,
+			"cannot set BTC SWAP_OUT rate to -1 ppm",
+		},
+		"LBTC SwapIn positive bad": {
+			premium.LBTC, premium.SwapIn, 100, 1000, true,
+			"cannot set LBTC SWAP_IN rate to 100 ppm",
+		},
+		"LBTC SwapOut negative bad": {
+			premium.LBTC, premium.SwapOut, -100, 0, true,
+			"cannot set LBTC SWAP_OUT rate to -100 ppm",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			setting := setupPremium(t)
+			if tt.operation == premium.SwapIn {
+				complement := lo.Must(premium.NewPremiumRate(
+					tt.asset, premium.SwapOut, premium.NewPPM(tt.complement)))
+				_ = setting.SetDefaultRate(context.Background(), complement)
+			} else {
+				complement := lo.Must(premium.NewPremiumRate(
+					tt.asset, premium.SwapIn, premium.NewPPM(tt.complement)))
+				_ = setting.SetDefaultRate(context.Background(), complement)
+			}
+			rate := lo.Must(premium.NewPremiumRate(
+				tt.asset, tt.operation, premium.NewPPM(tt.ppm)))
+			err := setting.ValidateDefaultRate(rate)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.wantContain) {
+				t.Fatalf("expected error containing %q, got: %v",
+					tt.wantContain, err)
+			}
+		})
+	}
+}
+
+func Test_ValidateRate_SameAssetSum(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		asset        premium.AssetType
+		existingIn   int64
+		existingOut  int64
+		setOp        premium.OperationType
+		setPPM       int64
+		wantErr      bool
+		wantContains string
+	}{
+		"BTC sum positive ok": {
+			premium.BTC, 0, 0, premium.SwapOut, 2000, false, "",
+		},
+		"BTC sum zero bad": {
+			premium.BTC, 0, 0, premium.SwapOut, 0, true,
+			"SWAP_OUT then SWAP_IN",
+		},
+		"BTC sum negative bad": {
+			premium.BTC, 0, 0, premium.SwapIn, -3000, true,
+			"SWAP_OUT then SWAP_IN",
+		},
+		"BTC boundary sum=1 ok": {
+			premium.BTC, 0, 0, premium.SwapOut, 1, false, "",
+		},
+		"BTC boundary -999999+999999=0 bad": {
+			premium.BTC, -999999, 0, premium.SwapOut, 999999, true,
+			"must be > 0",
+		},
+		"LBTC sum positive ok": {
+			premium.LBTC, -500, 0, premium.SwapOut, 1000, false, "",
+		},
+		"hint about order of operations": {
+			premium.BTC, 0, 0, premium.SwapIn, -100, true,
+			"increase the SWAP_OUT rate first",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			setting := setupPremium(t)
+			rateIn := lo.Must(premium.NewPremiumRate(
+				tt.asset, premium.SwapIn, premium.NewPPM(tt.existingIn)))
+			_ = setting.SetDefaultRate(context.Background(), rateIn)
+			rateOut := lo.Must(premium.NewPremiumRate(
+				tt.asset, premium.SwapOut, premium.NewPPM(tt.existingOut)))
+			_ = setting.SetDefaultRate(context.Background(), rateOut)
+
+			rate := lo.Must(premium.NewPremiumRate(
+				tt.asset, tt.setOp, premium.NewPPM(tt.setPPM)))
+			err := setting.ValidateDefaultRate(rate)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if tt.wantErr && tt.wantContains != "" &&
+				!strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("expected error containing %q, got: %v",
+					tt.wantContains, err)
+			}
+		})
+	}
+}
+
+func Test_ValidateRate_CrossAssetSum(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		lbtcSwapIn int64
+		btcSwapIn  int64
+		btcSwapOut int64
+		setAsset   premium.AssetType
+		setOp      premium.OperationType
+		setPPM     int64
+		wantErr    bool
+	}{
+		"cross sum positive via BTC SwapOut": {
+			-500, 0, 0, premium.BTC, premium.SwapOut, 1000, false,
+		},
+		"cross sum zero via BTC SwapOut": {
+			-200, -100, 0, premium.BTC, premium.SwapOut, 200, true,
+		},
+		"cross sum negative via LBTC SwapIn": {
+			0, 0, 500, premium.LBTC, premium.SwapIn, -1000, true,
+		},
+		"cross sum positive via LBTC SwapIn": {
+			0, 0, 2000, premium.LBTC, premium.SwapIn, -500, false,
+		},
+		"BTC SwapIn does not trigger cross check": {
+			0, 0, 5000, premium.BTC, premium.SwapIn, -100, false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			setting := setupPremium(t)
+			// Set up all four rates so same-asset sum checks pass.
+			lbtcIn := lo.Must(premium.NewPremiumRate(
+				premium.LBTC, premium.SwapIn, premium.NewPPM(tt.lbtcSwapIn)))
+			_ = setting.SetDefaultRate(context.Background(), lbtcIn)
+			lbtcOut := lo.Must(premium.NewPremiumRate(
+				premium.LBTC, premium.SwapOut, premium.NewPPM(5000)))
+			_ = setting.SetDefaultRate(context.Background(), lbtcOut)
+			btcOut := lo.Must(premium.NewPremiumRate(
+				premium.BTC, premium.SwapOut, premium.NewPPM(tt.btcSwapOut)))
+			_ = setting.SetDefaultRate(context.Background(), btcOut)
+			btcIn := lo.Must(premium.NewPremiumRate(
+				premium.BTC, premium.SwapIn, premium.NewPPM(tt.btcSwapIn)))
+			_ = setting.SetDefaultRate(context.Background(), btcIn)
+
+			rate := lo.Must(premium.NewPremiumRate(
+				tt.setAsset, tt.setOp, premium.NewPPM(tt.setPPM)))
+			err := setting.ValidateDefaultRate(rate)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if tt.wantErr &&
+				!strings.Contains(err.Error(), "LBTC_SWAP_IN + BTC_SWAP_OUT") {
+				t.Fatalf("expected error about cross-asset sum, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_ValidateRate_PeerSpecific(t *testing.T) {
+	t.Parallel()
+	setting := setupPremium(t)
+	peerID := "test-peer-validate"
+
+	outRate := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapOut, premium.NewPPM(3000)))
+	_ = setting.SetRate(context.Background(), peerID, outRate)
+
+	// -2000 + 3000 = 1000 > 0, should pass
+	inRate := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapIn, premium.NewPPM(-2000)))
+	if err := setting.ValidateRate(peerID, inRate); err != nil {
+		t.Fatalf("expected no error but got: %v", err)
+	}
+
+	// -4000 + 3000 = -1000 <= 0, should fail
+	badIn := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapIn, premium.NewPPM(-4000)))
+	if err := setting.ValidateRate(peerID, badIn); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func Test_ValidateRate_OrderOfOperations(t *testing.T) {
+	t.Parallel()
+	setting := setupPremium(t)
+
+	// Start with valid rates: SWAP_IN=-1000, SWAP_OUT=1500 (sum=500 > 0).
+	setDefault := func(asset premium.AssetType, op premium.OperationType, ppm int64) {
+		r := lo.Must(premium.NewPremiumRate(asset, op, premium.NewPPM(ppm)))
+		_ = setting.SetDefaultRate(context.Background(), r)
+	}
+	setDefault(premium.BTC, premium.SwapIn, -1000)
+	setDefault(premium.BTC, premium.SwapOut, 1500)
+
+	// Target: SWAP_IN=-2000, SWAP_OUT=2500 (sum=500 > 0, also valid).
+
+	// Wrong order: decrease SWAP_IN first.
+	// -2000 + 1500 = -500 <= 0 -> should fail.
+	wrongFirst := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapIn, premium.NewPPM(-2000)))
+	if err := setting.ValidateDefaultRate(wrongFirst); err == nil {
+		t.Fatal("wrong order: expected error when decreasing SWAP_IN first")
+	}
+
+	// Correct order: increase SWAP_OUT first.
+	// -1000 + 2500 = 1500 > 0 -> should pass.
+	correctFirst := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapOut, premium.NewPPM(2500)))
+	if err := setting.ValidateDefaultRate(correctFirst); err != nil {
+		t.Fatalf("correct order step 1: expected no error but got: %v", err)
+	}
+	setDefault(premium.BTC, premium.SwapOut, 2500)
+
+	// Now decrease SWAP_IN.
+	// -2000 + 2500 = 500 > 0 -> should pass.
+	correctSecond := lo.Must(premium.NewPremiumRate(
+		premium.BTC, premium.SwapIn, premium.NewPPM(-2000)))
+	if err := setting.ValidateDefaultRate(correctSecond); err != nil {
+		t.Fatalf("correct order step 2: expected no error but got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Log warnings when operators set premium rates that may work against their own interest
- Rates are always accepted — warnings surface in logs for operators and UI tools to act on
- No API changes, no new dependencies

## Checks implemented (from #394)

- **Check 1**: SWAP_IN rate should be ≤ 0, SWAP_OUT rate should be ≥ 0
- **Check 2**: same-asset SWAP_IN + SWAP_OUT must be > 0 (prevents swap cycling profit)
- **Check 4**: LBTC_SWAP_IN + BTC_SWAP_OUT must be > 0 (prevents cross-asset arbitrage via free peg-in)

## Checks skipped

- **Check 3**: BTC_SWAP_IN + LBTC_SWAP_OUT > boltz_peg_out_rate — requires external Boltz rate data, left as TODO comment

## Design

Per maintainer feedback on #394, this is implemented as **log warnings** rather than hard blocks. Operators who intentionally use unusual rates (promotional campaigns, liquidity strategies) are not prevented from doing so. UI tools like peerswap-web can implement stricter guardrails on top of the validation functions exposed by the `premium` package.

## Test plan

- [x] Unit tests for each validation check (sign convention, same-asset sum, cross-asset sum)
- [x] Boundary value tests (±1, -999999+999999=0)
- [x] BTC and LBTC symmetry tests
- [x] Peer-specific rate lookup test
- [x] Order-of-operations end-to-end test (proves the hint in error messages works)
- [x] `go test ./...` passes
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)