### PR TITLE
peersync: Keep connected peers in listpeers

### DIFF
--- a/peersync/message_handler.go
+++ b/peersync/message_handler.go
@@ -65,43 +65,21 @@ func (h *messageHandler) handlePollMessage(ctx context.Context, msg CustomMessag
 		return
 	}
 
-	peerID, capability, err := h.parsePollMessage(msg)
+	peerID, err := h.storeCapabilityMessage(msg)
 	if err != nil {
-		log.Printf("failed to parse poll message: %v", err)
+		log.Printf("failed to store poll message: %v", err)
 		return
-	}
-
-	if h.guard != nil && h.guard.Suspicious(peerID) {
-		return
-	}
-
-	peer, err := h.findPeer(peerID)
-	if err != nil {
-		log.Printf("unknown peer %s: %v", peerID.String(), err)
-		return
-	}
-
-	if existing := peer.Capability(); existing != nil {
-		capability = h.logic.MergeCapabilities(existing, capability)
-	}
-
-	peer.UpdateCapability(capability)
-
-	if err := h.store.SavePeerState(peer); err != nil {
-		log.Printf("failed to store peer state: %v", err)
 	}
 
 	pslog.Infof("Received poll from peer %s", peerID.String())
 }
 
 func (h *messageHandler) handleRequestPollMessage(ctx context.Context, msg CustomMessage) {
-	var payload RequestPollMessageDTO
-	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
-		log.Printf("failed to decode request poll message: %v", err)
+	fromPeerID, err := h.storeCapabilityMessage(msg)
+	if err != nil {
+		log.Printf("failed to store request poll message: %v", err)
 		return
 	}
-
-	fromPeerID := msg.From
 
 	if h.guard != nil && h.guard.Suspicious(fromPeerID) {
 		return
@@ -117,19 +95,47 @@ func (h *messageHandler) handleRequestPollMessage(ctx context.Context, msg Custo
 	}
 }
 
-func (h *messageHandler) parsePollMessage(msg CustomMessage) (PeerID, *PeerCapability, error) {
+func (h *messageHandler) storeCapabilityMessage(msg CustomMessage) (PeerID, error) {
 	peerID := msg.From
-	var payload PollMessageDTO
+	capability, err := h.parseCapabilityMessage(msg)
+	if err != nil {
+		return peerID, err
+	}
+
+	if h.guard != nil && h.guard.Suspicious(peerID) {
+		return peerID, nil
+	}
+
+	peer, err := h.findPeer(peerID)
+	if err != nil {
+		return peerID, fmt.Errorf("unknown peer %s: %w", peerID.String(), err)
+	}
+
+	if existing := peer.Capability(); existing != nil {
+		capability = h.logic.MergeCapabilities(existing, capability)
+	}
+
+	peer.UpdateCapability(capability)
+
+	if err := h.store.SavePeerState(peer); err != nil {
+		return peerID, fmt.Errorf("failed to store peer state: %w", err)
+	}
+
+	return peerID, nil
+}
+
+func (h *messageHandler) parseCapabilityMessage(msg CustomMessage) (*PeerCapability, error) {
+	var payload PeerCapabilitySnapshot
 	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
-		return peerID, nil, fmt.Errorf("decode poll message: %w", err)
+		return nil, fmt.Errorf("decode capability message: %w", err)
 	}
 
 	capability, err := payload.ToCapability()
 	if err != nil {
-		return peerID, nil, fmt.Errorf("invalid poll payload: %w", err)
+		return nil, fmt.Errorf("invalid capability payload: %w", err)
 	}
 
-	return peerID, capability, nil
+	return capability, nil
 }
 
 func (h *messageHandler) findPeer(peerID PeerID) (*Peer, error) {

--- a/peersync/message_handler.go
+++ b/peersync/message_handler.go
@@ -75,14 +75,17 @@ func (h *messageHandler) handlePollMessage(ctx context.Context, msg CustomMessag
 }
 
 func (h *messageHandler) handleRequestPollMessage(ctx context.Context, msg CustomMessage) {
-	fromPeerID, err := h.storeCapabilityMessage(msg)
-	if err != nil {
-		log.Printf("failed to store request poll message: %v", err)
-		return
-	}
+	fromPeerID := msg.From
 
 	if h.guard != nil && h.guard.Suspicious(fromPeerID) {
 		return
+	}
+
+	// Storing the requester's capability is best effort: the response is
+	// what keeps this node visible to the peer, so it must go out even
+	// when the payload cannot be parsed or persisted.
+	if _, err := h.storeCapabilityMessage(msg); err != nil {
+		log.Printf("failed to store request poll message: %v", err)
 	}
 
 	if h.send == nil {

--- a/peersync/peersync.go
+++ b/peersync/peersync.go
@@ -104,6 +104,7 @@ func NewPeerSync(
 	ps.poller = newPoller(
 		ps.logic,
 		ps.store,
+		ps.lightning,
 		ps.guard,
 		ps.sendCapability,
 		ps.pollTickerInterval,

--- a/peersync/peersync.go
+++ b/peersync/peersync.go
@@ -72,6 +72,7 @@ type PeerSync struct {
 	pollTickerInterval    time.Duration
 	cleanupTickerInterval time.Duration
 	cleanupTimeout        time.Duration
+	requestPollInterval   time.Duration
 }
 
 type capabilitySender func(ctx context.Context, peer PeerID, msgType messages.MessageType) error
@@ -99,6 +100,7 @@ func NewPeerSync(
 		pollTickerInterval:    10 * time.Second,
 		cleanupTickerInterval: 1 * time.Minute,
 		cleanupTimeout:        30 * time.Minute,
+		requestPollInterval:   10 * time.Minute,
 	}
 
 	ps.poller = newPoller(
@@ -110,6 +112,7 @@ func NewPeerSync(
 		ps.pollTickerInterval,
 		ps.cleanupTickerInterval,
 		ps.cleanupTimeout,
+		ps.requestPollInterval,
 	)
 	ps.handler = newMessageHandler(ps.store, ps.logic, ps.guard, ps.sendCapability)
 

--- a/peersync/poller.go
+++ b/peersync/poller.go
@@ -9,11 +9,12 @@ import (
 )
 
 type poller struct {
-	logic   *SyncLogic
-	store   *Store
-	guard   PeerGuard
-	send    capabilitySender
-	timeout time.Duration
+	logic     *SyncLogic
+	store     *Store
+	lightning Lightning
+	guard     PeerGuard
+	send      capabilitySender
+	timeout   time.Duration
 
 	pollTickerInterval    time.Duration
 	cleanupTickerInterval time.Duration
@@ -22,6 +23,7 @@ type poller struct {
 func newPoller(
 	logic *SyncLogic,
 	store *Store,
+	lightning Lightning,
 	guard PeerGuard,
 	send capabilitySender,
 	pollTickerInterval time.Duration,
@@ -31,6 +33,7 @@ func newPoller(
 	return &poller{
 		logic:                 logic,
 		store:                 store,
+		lightning:             lightning,
 		guard:                 guard,
 		send:                  send,
 		timeout:               cleanupTimeout,
@@ -79,11 +82,23 @@ func (p *poller) runCleanupLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if _, err := p.store.CleanupExpired(p.timeout); err != nil {
+			if err := p.cleanupExpired(ctx); err != nil {
 				log.Printf("cleanup expired peers failed: %v", err)
 			}
 		}
 	}
+}
+
+func (p *poller) cleanupExpired(ctx context.Context) error {
+	connected, err := p.connectedPeers(ctx)
+	if err != nil {
+		log.Printf("failed to list connected peers for cleanup: %v", err)
+		_, cleanupErr := p.store.CleanupExpired(p.timeout)
+		return cleanupErr
+	}
+
+	_, err = p.store.CleanupExpiredExcept(p.timeout, connected)
+	return err
 }
 
 func (p *poller) PollAllPeers(ctx context.Context) {
@@ -114,10 +129,13 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 		return
 	}
 
+	knownPeers := make(map[string]*Peer, len(peers))
+
 	for _, peer := range peers {
 		if peer == nil {
 			continue
 		}
+		knownPeers[peer.ID().String()] = peer
 		if !force && !p.logic.ShouldPoll(peer) {
 			continue
 		}
@@ -136,4 +154,42 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 			log.Printf("failed to persist peer state for %s: %v", peer.ID().String(), err)
 		}
 	}
+
+	p.requestUnknownConnectedPeers(ctx, knownPeers)
+}
+
+func (p *poller) requestUnknownConnectedPeers(ctx context.Context, knownPeers map[string]*Peer) {
+	connected, err := p.connectedPeers(ctx)
+	if err != nil {
+		log.Printf("failed to list connected peers for poll: %v", err)
+		return
+	}
+
+	for peerID := range connected {
+		if _, ok := knownPeers[peerID.String()]; ok {
+			continue
+		}
+		if p.guard != nil && p.guard.Suspicious(peerID) {
+			continue
+		}
+		if err := p.send(ctx, peerID, messages.MESSAGETYPE_REQUEST_POLL); err != nil {
+			log.Printf("failed to request poll from %s: %v", peerID.String(), err)
+		}
+	}
+}
+
+func (p *poller) connectedPeers(ctx context.Context) (map[PeerID]struct{}, error) {
+	connected := make(map[PeerID]struct{})
+	if p.lightning == nil {
+		return connected, nil
+	}
+
+	peers, err := p.lightning.ListPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, peerID := range peers {
+		connected[peerID] = struct{}{}
+	}
+	return connected, nil
 }

--- a/peersync/poller.go
+++ b/peersync/poller.go
@@ -2,6 +2,7 @@ package peersync
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -92,9 +93,7 @@ func (p *poller) runCleanupLoop(ctx context.Context) {
 func (p *poller) cleanupExpired(ctx context.Context) error {
 	connected, err := p.connectedPeers(ctx)
 	if err != nil {
-		log.Printf("failed to list connected peers for cleanup: %v", err)
-		_, cleanupErr := p.store.CleanupExpired(p.timeout)
-		return cleanupErr
+		return fmt.Errorf("skipping cleanup sweep, list connected peers: %w", err)
 	}
 
 	_, err = p.store.CleanupExpiredExcept(p.timeout, connected)

--- a/peersync/poller.go
+++ b/peersync/poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/elementsproject/peerswap/messages"
@@ -19,6 +20,10 @@ type poller struct {
 
 	pollTickerInterval    time.Duration
 	cleanupTickerInterval time.Duration
+	requestInterval       time.Duration
+
+	mu              sync.Mutex
+	lastRequestedAt map[PeerID]time.Time
 }
 
 func newPoller(
@@ -30,6 +35,7 @@ func newPoller(
 	pollTickerInterval time.Duration,
 	cleanupTickerInterval time.Duration,
 	cleanupTimeout time.Duration,
+	requestInterval time.Duration,
 ) *poller {
 	return &poller{
 		logic:                 logic,
@@ -40,6 +46,8 @@ func newPoller(
 		timeout:               cleanupTimeout,
 		pollTickerInterval:    pollTickerInterval,
 		cleanupTickerInterval: cleanupTickerInterval,
+		requestInterval:       requestInterval,
+		lastRequestedAt:       make(map[PeerID]time.Time),
 	}
 }
 
@@ -128,13 +136,13 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 		return
 	}
 
-	knownPeers := make(map[string]*Peer, len(peers))
+	knownPeers := make(map[PeerID]struct{}, len(peers))
 
 	for _, peer := range peers {
 		if peer == nil {
 			continue
 		}
-		knownPeers[peer.ID().String()] = peer
+		knownPeers[peer.ID()] = struct{}{}
 		if !force && !p.logic.ShouldPoll(peer) {
 			continue
 		}
@@ -154,25 +162,59 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 		}
 	}
 
-	p.requestUnknownConnectedPeers(ctx, knownPeers)
+	p.requestUnknownConnectedPeers(ctx, knownPeers, force)
 }
 
-func (p *poller) requestUnknownConnectedPeers(ctx context.Context, knownPeers map[string]*Peer) {
+func (p *poller) requestUnknownConnectedPeers(ctx context.Context, knownPeers map[PeerID]struct{}, force bool) {
 	connected, err := p.connectedPeers(ctx)
 	if err != nil {
 		log.Printf("failed to list connected peers for poll: %v", err)
 		return
 	}
 
+	p.pruneRequestTimes(connected)
+
+	now := time.Now()
 	for peerID := range connected {
-		if _, ok := knownPeers[peerID.String()]; ok {
+		if _, ok := knownPeers[peerID]; ok {
 			continue
 		}
 		if p.guard != nil && p.guard.Suspicious(peerID) {
 			continue
 		}
+		if !p.allowRequest(peerID, now, force) {
+			continue
+		}
 		if err := p.send(ctx, peerID, messages.MESSAGETYPE_REQUEST_POLL); err != nil {
 			log.Printf("failed to request poll from %s: %v", peerID.String(), err)
+		}
+	}
+}
+
+// allowRequest records the request attempt and reports whether a poll
+// request may be sent to the peer. Attempts are recorded even when the
+// send later fails so that unresponsive peers are contacted at most once
+// per request interval.
+func (p *poller) allowRequest(peerID PeerID, now time.Time, force bool) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if last, ok := p.lastRequestedAt[peerID]; ok && !force && now.Sub(last) < p.requestInterval {
+		return false
+	}
+	p.lastRequestedAt[peerID] = now
+	return true
+}
+
+// pruneRequestTimes drops request timestamps of peers that are no longer
+// connected, so a peer that reconnects is requested again immediately.
+func (p *poller) pruneRequestTimes(connected map[PeerID]struct{}) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for id := range p.lastRequestedAt {
+		if _, ok := connected[id]; !ok {
+			delete(p.lastRequestedAt, id)
 		}
 	}
 }

--- a/peersync/poller.go
+++ b/peersync/poller.go
@@ -137,6 +137,7 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 	}
 
 	knownPeers := make(map[PeerID]struct{}, len(peers))
+	now := time.Now()
 
 	for _, peer := range peers {
 		if peer == nil {
@@ -151,7 +152,12 @@ func (p *poller) pollPeers(ctx context.Context, force bool) {
 			continue
 		}
 
-		if err := p.send(ctx, peer.ID(), messages.MESSAGETYPE_POLL); err != nil {
+		msgType := messages.MESSAGETYPE_POLL
+		if p.capabilityIsStale(peer, now) {
+			msgType = messages.MESSAGETYPE_REQUEST_POLL
+		}
+
+		if err := p.send(ctx, peer.ID(), msgType); err != nil {
 			log.Printf("failed to poll %s: %v", peer.ID().String(), err)
 			continue
 		}
@@ -189,6 +195,18 @@ func (p *poller) requestUnknownConnectedPeers(ctx context.Context, knownPeers ma
 			log.Printf("failed to request poll from %s: %v", peerID.String(), err)
 		}
 	}
+}
+
+// capabilityIsStale reports whether the peer's capability has not been
+// refreshed by an inbound poll for more than half the cleanup timeout.
+// Stale peers are sent a request poll instead of a plain poll so that
+// peers that only answer requests keep their stored capability current.
+func (p *poller) capabilityIsStale(peer *Peer, now time.Time) bool {
+	last := peer.LastObservedAt()
+	if last.IsZero() {
+		return false
+	}
+	return now.Sub(last) > p.timeout/2
 }
 
 // allowRequest records the request attempt and reports whether a poll

--- a/peersync/service_test.go
+++ b/peersync/service_test.go
@@ -178,6 +178,50 @@ func TestPollAllPeers(t *testing.T) {
 	}
 }
 
+func TestPollAllPeersRequestsUnknownConnectedPeers(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deps.lightning.peers = []PeerID{peerID}
+
+	syncer.PollAllPeers(context.Background())
+
+	sent := deps.lightning.SentMessages()
+	if len(sent) != 1 {
+		t.Fatalf("expected one request poll, got %d", len(sent))
+	}
+	if sent[0].to != peerID || sent[0].msgType != messages.MESSAGETYPE_REQUEST_POLL {
+		t.Fatalf("unexpected send: %+v", sent[0])
+	}
+}
+
+func TestCleanupKeepsExpiredConnectedPeers(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	peer := NewPeer(peerID, "addr-connected")
+	peer.UpdateCapability(NewPeerCapability(syncer.version, []Asset{AssetBTC}, true, nil, nil, nil, nil))
+	peer.SetLastObservedAt(time.Now().Add(-2 * syncer.cleanupTimeout))
+	if err := deps.store.SavePeerState(peer); err != nil {
+		t.Fatalf("failed to seed peer state: %v", err)
+	}
+	deps.lightning.peers = []PeerID{peerID}
+
+	if err := syncer.poller.cleanupExpired(context.Background()); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if _, err := deps.store.GetPeerState(peerID); err != nil {
+		t.Fatalf("expected connected peer to remain in store, got %v", err)
+	}
+}
+
 func TestHandlePollMessage(t *testing.T) {
 	syncer, deps := newTestPeerSync(t)
 
@@ -230,7 +274,15 @@ func TestHandleRequestPollMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	request := RequestPollMessageDTO{}
+	request := RequestPollMessageDTO{
+		Version:                   2,
+		Assets:                    []string{"BTC"},
+		PeerAllowed:               true,
+		BTCSwapInPremiumRatePPM:   100,
+		BTCSwapOutPremiumRatePPM:  200,
+		LBTCSwapInPremiumRatePPM:  300,
+		LBTCSwapOutPremiumRatePPM: 400,
+	}
 	data, err := json.Marshal(request)
 	if err != nil {
 		t.Fatalf("failed to marshal request: %v", err)
@@ -247,5 +299,16 @@ func TestHandleRequestPollMessage(t *testing.T) {
 
 	if deps.lightning.SentCount() != 1 {
 		t.Fatalf("expected response poll to be sent")
+	}
+
+	stored, err := deps.store.GetPeerState(peerID)
+	if err != nil {
+		t.Fatalf("expected request poll to store peer state: %v", err)
+	}
+	if stored.Capability() == nil {
+		t.Fatalf("expected capability to be stored")
+	}
+	if stored.Capability().Version().Value() != request.Version {
+		t.Fatalf("unexpected stored version: got %d want %d", stored.Capability().Version().Value(), request.Version)
 	}
 }

--- a/peersync/service_test.go
+++ b/peersync/service_test.go
@@ -172,6 +172,9 @@ func TestPollAllPeers(t *testing.T) {
 	if deps.lightning.SentCount() != 1 {
 		t.Fatalf("expected poll call, got %d", deps.lightning.SentCount())
 	}
+	if sent := deps.lightning.SentMessages(); sent[0].msgType != messages.MESSAGETYPE_POLL {
+		t.Fatalf("expected plain poll, got %v", sent[0].msgType)
+	}
 
 	saved, err := deps.store.GetPeerState(peerID)
 	if err != nil {
@@ -179,6 +182,33 @@ func TestPollAllPeers(t *testing.T) {
 	}
 	if saved.LastPollAt().IsZero() || !saved.LastPollAt().After(peer.LastPollAt()) {
 		t.Fatalf("expected peer state to be saved with updated timestamp")
+	}
+}
+
+func TestPollAllPeersRequestsStaleKnownPeers(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-stale")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	peer := NewPeer(peerID, "addr-stale")
+	peer.UpdateCapability(NewPeerCapability(syncer.version, []Asset{AssetBTC}, true, nil, nil, nil, nil))
+	peer.SetLastObservedAt(time.Now().Add(-(syncer.cleanupTimeout/2 + time.Minute)))
+	peer.SetLastPollAt(time.Now().Add(-time.Hour))
+	peer.SetStatus(StatusActive)
+	if err := deps.store.SavePeerState(peer); err != nil {
+		t.Fatalf("failed to seed peer state: %v", err)
+	}
+
+	syncer.PollAllPeers(context.Background())
+
+	sent := deps.lightning.SentMessages()
+	if len(sent) != 1 {
+		t.Fatalf("expected one poll call, got %d", len(sent))
+	}
+	if sent[0].to != peerID || sent[0].msgType != messages.MESSAGETYPE_REQUEST_POLL {
+		t.Fatalf("expected request poll for stale peer, got %+v", sent[0])
 	}
 }
 

--- a/peersync/service_test.go
+++ b/peersync/service_test.go
@@ -340,3 +340,44 @@ func TestHandleRequestPollMessage(t *testing.T) {
 		t.Fatalf("unexpected stored version: got %d want %d", stored.Capability().Version().Value(), request.Version)
 	}
 }
+
+func TestHandleRequestPollMessageRespondsOnInvalidPayload(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	ctx := context.Background()
+
+	peerID, err := NewPeerID("peer-future")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	request := RequestPollMessageDTO{
+		Version:     99,
+		Assets:      []string{"FUTURECOIN"},
+		PeerAllowed: true,
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	syncer.handler.handleRequestPollMessage(
+		ctx,
+		CustomMessage{
+			From:    peerID,
+			Type:    messages.MESSAGETYPE_REQUEST_POLL,
+			Payload: data,
+		},
+	)
+
+	sent := deps.lightning.SentMessages()
+	if len(sent) != 1 {
+		t.Fatalf("expected response poll despite invalid payload, got %d sends", len(sent))
+	}
+	if sent[0].to != peerID || sent[0].msgType != messages.MESSAGETYPE_POLL {
+		t.Fatalf("unexpected send: %+v", sent[0])
+	}
+
+	if _, err := deps.store.GetPeerState(peerID); !errors.Is(err, ErrPeerNotFound) {
+		t.Fatalf("expected invalid payload not to be stored, got %v", err)
+	}
+}

--- a/peersync/service_test.go
+++ b/peersync/service_test.go
@@ -3,6 +3,7 @@ package peersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -21,10 +22,11 @@ type (
 	stubLightning struct {
 		mu sync.Mutex
 
-		peers    []PeerID
-		ch       chan CustomMessage
-		startErr error
-		stopErr  error
+		peers        []PeerID
+		listPeersErr error
+		ch           chan CustomMessage
+		startErr     error
+		stopErr      error
 
 		sends   []sentCall
 		sendErr error
@@ -53,7 +55,9 @@ func (l *stubLightning) SubscribeCustomMessages(ctx context.Context) (<-chan Cus
 
 func (l *stubLightning) Stop() error { return l.stopErr }
 
-func (l *stubLightning) ListPeers(ctx context.Context) ([]PeerID, error) { return l.peers, nil }
+func (l *stubLightning) ListPeers(ctx context.Context) ([]PeerID, error) {
+	return l.peers, l.listPeersErr
+}
 
 func (l *stubLightning) recordSend(call sentCall) {
 	l.mu.Lock()
@@ -219,6 +223,30 @@ func TestCleanupKeepsExpiredConnectedPeers(t *testing.T) {
 
 	if _, err := deps.store.GetPeerState(peerID); err != nil {
 		t.Fatalf("expected connected peer to remain in store, got %v", err)
+	}
+}
+
+func TestCleanupSkipsSweepWhenListPeersFails(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-expired")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	peer := NewPeer(peerID, "addr-expired")
+	peer.UpdateCapability(NewPeerCapability(syncer.version, []Asset{AssetBTC}, true, nil, nil, nil, nil))
+	peer.SetLastObservedAt(time.Now().Add(-2 * syncer.cleanupTimeout))
+	if err := deps.store.SavePeerState(peer); err != nil {
+		t.Fatalf("failed to seed peer state: %v", err)
+	}
+	deps.lightning.listPeersErr = errors.New("rpc unavailable")
+
+	if err := syncer.poller.cleanupExpired(context.Background()); err == nil {
+		t.Fatalf("expected cleanup to report the ListPeers failure")
+	}
+
+	if _, err := deps.store.GetPeerState(peerID); err != nil {
+		t.Fatalf("expected peer to survive skipped sweep, got %v", err)
 	}
 }
 

--- a/peersync/service_test.go
+++ b/peersync/service_test.go
@@ -202,6 +202,68 @@ func TestPollAllPeersRequestsUnknownConnectedPeers(t *testing.T) {
 	}
 }
 
+func TestRequestUnknownPeersIsRateLimited(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deps.lightning.peers = []PeerID{peerID}
+
+	syncer.PollAllPeers(context.Background())
+	syncer.PollAllPeers(context.Background())
+
+	if deps.lightning.SentCount() != 1 {
+		t.Fatalf("expected repeated polls to send one request, got %d", deps.lightning.SentCount())
+	}
+}
+
+func TestForcePollBypassesRequestRateLimit(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deps.lightning.peers = []PeerID{peerID}
+
+	syncer.PollAllPeers(context.Background())
+	syncer.ForcePollAllPeers(context.Background())
+
+	sent := deps.lightning.SentMessages()
+	if len(sent) != 2 {
+		t.Fatalf("expected force poll to bypass rate limit, got %d sends", len(sent))
+	}
+	for _, call := range sent {
+		if call.to != peerID || call.msgType != messages.MESSAGETYPE_REQUEST_POLL {
+			t.Fatalf("unexpected send: %+v", call)
+		}
+	}
+}
+
+func TestRequestRateLimitClearsOnDisconnect(t *testing.T) {
+	syncer, deps := newTestPeerSync(t)
+
+	peerID, err := NewPeerID("peer-connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deps.lightning.peers = []PeerID{peerID}
+
+	syncer.PollAllPeers(context.Background())
+
+	deps.lightning.peers = nil
+	syncer.PollAllPeers(context.Background())
+
+	deps.lightning.peers = []PeerID{peerID}
+	syncer.PollAllPeers(context.Background())
+
+	if deps.lightning.SentCount() != 2 {
+		t.Fatalf("expected reconnect to reset rate limit, got %d sends", deps.lightning.SentCount())
+	}
+}
+
 func TestCleanupKeepsExpiredConnectedPeers(t *testing.T) {
 	syncer, deps := newTestPeerSync(t)
 

--- a/peersync/store.go
+++ b/peersync/store.go
@@ -159,6 +159,11 @@ func (s *Store) RemovePeerState(id PeerID) error {
 
 // CleanupExpired removes peers whose last observation exceeds the timeout.
 func (s *Store) CleanupExpired(timeout time.Duration) (int, error) {
+	return s.CleanupExpiredExcept(timeout, nil)
+}
+
+// CleanupExpiredExcept removes expired peers unless their IDs are in keepPeers.
+func (s *Store) CleanupExpiredExcept(timeout time.Duration, keepPeers map[PeerID]struct{}) (int, error) {
 	if timeout <= 0 {
 		return 0, errors.New("timeout must be positive")
 	}
@@ -172,6 +177,9 @@ func (s *Store) CleanupExpired(timeout time.Duration) (int, error) {
 
 		cursor := bucket.Cursor()
 		for key, value := cursor.First(); key != nil; key, value = cursor.Next() {
+			if shouldKeepPeer(key, keepPeers) {
+				continue
+			}
 			removedPeer, err := s.processPeerRecord(bucket, cursor, key, value, timeout)
 			if err != nil {
 				return err
@@ -192,6 +200,19 @@ func (s *Store) CleanupExpired(timeout time.Duration) (int, error) {
 	}
 
 	return removed, nil
+}
+
+func shouldKeepPeer(key []byte, keepPeers map[PeerID]struct{}) bool {
+	if len(keepPeers) == 0 {
+		return false
+	}
+
+	peerID, err := NewPeerID(string(key))
+	if err != nil {
+		return false
+	}
+	_, ok := keepPeers[peerID]
+	return ok
 }
 
 func (s *Store) processPeerRecord(

--- a/peersync/store_test.go
+++ b/peersync/store_test.go
@@ -108,6 +108,51 @@ func TestStoreCleanupExpired(t *testing.T) {
 	}
 }
 
+func TestStoreCleanupExpiredExceptKeepsListedPeer(t *testing.T) {
+	store := newTestStore(t)
+
+	timeout := 10 * time.Minute
+
+	keptID, err := NewPeerID("kept-peer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	keptPeer := NewPeer(keptID, "addr-kept")
+	keptPeer.SetStatus(StatusActive)
+	keptPeer.SetLastObservedAt(time.Now().Add(-2 * timeout))
+	if err := store.SavePeerState(keptPeer); err != nil {
+		t.Fatalf("failed to store kept peer: %v", err)
+	}
+
+	removedID, err := NewPeerID("removed-peer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	removedPeer := NewPeer(removedID, "addr-removed")
+	removedPeer.SetStatus(StatusActive)
+	removedPeer.SetLastObservedAt(time.Now().Add(-2 * timeout))
+	if err := store.SavePeerState(removedPeer); err != nil {
+		t.Fatalf("failed to store removed peer: %v", err)
+	}
+
+	count, err := store.CleanupExpiredExcept(timeout, map[PeerID]struct{}{keptID: {}})
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if count != 1 {
+		t.Fatalf("expected 1 expired peer removed, got %d", count)
+	}
+
+	if _, err := store.GetPeerState(removedID); !errors.Is(err, ErrPeerNotFound) {
+		t.Fatalf("expected ErrPeerNotFound, got %v", err)
+	}
+
+	if _, err := store.GetPeerState(keptID); err != nil {
+		t.Fatalf("expected kept peer to remain in store, got %v", err)
+	}
+}
+
 type legacyPollInfo struct {
 	ProtocolVersion           uint64   `json:"version"`
 	Assets                    []string `json:"assets"`


### PR DESCRIPTION
Fixes #425.

`pscli listpeers` shows the intersection of the node's connected peers and the peersync store, so a peer that drops out of the store disappears from the list even while its LND channel stays active.

## Root cause of the report

The reporter's build (the log shows commit 8f67039) predates the peersync package and ran the legacy `poll` service: `poll.NewService(1*time.Hour, 2*time.Hour, ...)` requests polls from all peers once at startup, then on every hourly tick removes peers unseen for more than two hours and broadcasts plain polls. Strike answers request polls but does not broadcast polls on its own, so its `LastSeen` was set once at startup (05:48) and never refreshed. The hourly ticks at 06:48 and 07:48 left it alone; the 08:48 tick found it more than two hours stale and removed it — matching the observed disappearance at 08:49. After removal only plain polls are sent, which solicit no reply, so the peer never reappears until peerswap restarts.

Current master has the same failure class in a worse form: peersync polls only peers already in its store, refreshes `lastObservedAt` only on inbound polls, removes peers after 30 minutes, and never contacts a removed peer again. A peer like Strike would vanish about half an hour after startup instead of three hours.

## Fix

- Keep connected peers in the store during the cleanup sweep (`CleanupExpiredExcept`), and skip the sweep entirely when listing connected peers fails instead of falling back to an unconditional sweep.
- Request polls from connected peers that are missing from the store, rate-limited to one request per peer per ten minutes (forced polls bypass the limit; timestamps reset when a peer disconnects).
- Store capabilities carried by request polls, restoring parity with the legacy poll service, and keep answering request polls even when the payload cannot be parsed or persisted so this node stays visible to the requester.
- Send a request poll instead of a plain poll to known peers whose capability has not been refreshed for more than half the cleanup timeout, so peers that only answer requests keep their stored data current.
