### PR TITLE
fix: peersync - case insensitive asset parsing

### DIFF
--- a/peersync/peer.go
+++ b/peersync/peer.go
@@ -4,6 +4,7 @@ package peersync
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/elementsproject/peerswap/premium"
@@ -34,7 +35,8 @@ var (
 
 // NewAsset converts a ticker into the corresponding enum value.
 func NewAsset(value string) (Asset, error) {
-	if asset, ok := stringToAsset[value]; ok {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	if asset, ok := stringToAsset[normalized]; ok {
 		return asset, nil
 	}
 	return AssetUnknown, fmt.Errorf("unsupported asset: %s", value)

--- a/peersync/peer_test.go
+++ b/peersync/peer_test.go
@@ -275,8 +275,21 @@ func TestAssetValidation(t *testing.T) {
 		t.Fatalf("expected asset LBTC string to be LBTC, got %s", b.String())
 	}
 
-	if _, err = NewAsset("lower"); err == nil {
-		t.Fatalf("expected error for lowercase asset")
+	// v5.0.0 peers send lowercase symbols — must be accepted
+	c, err := NewAsset("btc")
+	if err != nil {
+		t.Fatalf("expected no error for lowercase btc, got %v", err)
+	}
+	if c != AssetBTC {
+		t.Fatalf("expected lowercase btc to resolve to AssetBTC")
+	}
+
+	d, err := NewAsset("lbtc")
+	if err != nil {
+		t.Fatalf("expected no error for lowercase lbtc, got %v", err)
+	}
+	if d != AssetLBTC {
+		t.Fatalf("expected lowercase lbtc to resolve to AssetLBTC")
 	}
 
 	if _, err = NewAsset("TOO-LONG-ASSET"); err == nil {


### PR DESCRIPTION
## Context

Related to https://github.com/ElementsProject/peerswap/issues/435
                                                                        
Nodes running the `peersync`-based daemon (post-v5.0.0) silently drop all inbound poll messages from peers still on v5.0.0, causing a one-way compatibility break.                                   

`NewAsset()` performs a direct map lookup against `stringToAsset`, which only contains uppercase keys (`"BTC"`, `"LBTC"`). v5.0.0 nodes advertise assets in lowercase in their poll payloads. The lookup fails, the poll is discarded, and `observedAt` never refreshes on the remote side. The remote peer ages the node off their active list within hours and cannot recover without restarting their daemon.                               
                                                                                    
### Logs on the node show: 
```                                                     
  failed to parse poll message: invalid poll payload: unsupported asset: btc
  failed to parse poll message: invalid poll payload: unsupported asset: lbtc
```

### Fix                                                                            
Normalize the input with `strings.ToUpper` before lookup so both uppercase and lowercase symbols are accepted.             

### Testing                                                                        
Verified manually against a v5.0.0 peer. Poll messages containing lowercase `"btc"`/`"lbtc"` are now parsed correctly and `observedAt` stays current.