### PR TITLE
Format wallet send amounts exactly

### DIFF
--- a/wallet/elementsrpcwallet.go
+++ b/wallet/elementsrpcwallet.go
@@ -213,6 +213,7 @@ const (
 	// 1 kb = 1000 bytes
 	kb              = 1000
 	btcToSatoshiExp = 8
+	satsPerBitcoin  = 100000000
 )
 
 func (r *ElementsRpcWallet) GetFee(txSize int64) (uint64, error) {
@@ -231,8 +232,7 @@ func (r *ElementsRpcWallet) SetLabel(txID, address, label string) error {
 
 // satsToAmountString returns the amount in btc from sats
 func satsToAmountString(sats uint64) string {
-	bitcoinAmt := float64(sats) / 100000000
-	return fmt.Sprintf("%f", bitcoinAmt)
+	return fmt.Sprintf("%d.%08d", sats/satsPerBitcoin, sats%satsPerBitcoin)
 }
 
 func (r *ElementsRpcWallet) Ping() (bool, error) {

--- a/wallet/elementsrpcwallet_test.go
+++ b/wallet/elementsrpcwallet_test.go
@@ -1,0 +1,47 @@
+package wallet
+
+import (
+	"testing"
+)
+
+func TestSatsToAmountString(t *testing.T) {
+	tests := []struct {
+		name string
+		sats uint64
+		want string
+	}{
+		{
+			name: "zero",
+			sats: 0,
+			want: "0.00000000",
+		},
+		{
+			name: "single sat",
+			sats: 1,
+			want: "0.00000001",
+		},
+		{
+			name: "issue example keeps sat precision",
+			sats: 123456142,
+			want: "1.23456142",
+		},
+		{
+			name: "whole bitcoin keeps decimal places",
+			sats: satsPerBitcoin,
+			want: "1.00000000",
+		},
+		{
+			name: "max uint64",
+			sats: ^uint64(0),
+			want: "184467440737.09551615",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := satsToAmountString(tt.sats); got != tt.want {
+				t.Fatalf("satsToAmountString(%d) = %q, want %q", tt.sats, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- format satoshi amounts with integer arithmetic before calling elementsd
- preserve all 8 decimal places instead of relying on `%f` default precision
- add coverage for the reported amount plus small, whole-coin, and max-value cases

Fixes #442

## Tests
- go test ./wallet -run TestSatsToAmountString -count=1 -v
- go test ./wallet -count=1
