### PR TITLE
lnd: Support LND 0.21 payment RPCs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777325693,
-        "narHash": "sha256-jFOEQwFDRVghCDFu0mybSLeTk9zWJSQW9clWFMkCa5A=",
+        "lastModified": 1781782487,
+        "narHash": "sha256-HUiiSSjhod2Mln/GIQAA56LB/kXXm2Pc5NdB731IBw0=",
         "owner": "Blockstream",
         "repo": "electrs",
-        "rev": "503b740cce2133fd07f451cbe93249a4e092b300",
+        "rev": "c7956023c3bf2cb3ac8076a4f65ebdf14b509513",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1778106249,
-        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778458615,
-        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778555852,
-        "narHash": "sha256-55EmwooVAS4UpA0oWd5wilKPRqCiHD5BAej9QiNwheY=",
+        "lastModified": 1781752752,
+        "narHash": "sha256-kVG5tV9hddPviGAgqf9sGSuStvv+HAB9onfKqGptV0k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f29b0f7a9f367e0056b716f8aa137cb41e784444",
+        "rev": "c06d86dabe5b92982b9d67acccb9990d58da3a0e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     # Base packages for devShell.
-    # nixpkgs is pinned via `flake.lock` (currently rev f997fa0f94fb1ce55bccb97f60d41412ae8fde4c).
+    # nixpkgs is pinned via `flake.lock` (currently rev 3e41b24abd260e8f71dbe2f5737d24122f972158).
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
@@ -70,7 +70,7 @@
             # Lightning implementations (used by integration tests / local setups).
             # Version checks:
             # - `lightningd --version` (Core Lightning / clightning 26.04.1)
-            # - `lnd --version` (lnd 0.20.1-beta)
+            # - `lnd --version` (lnd 0.21.0-beta)
             clightning
             lnd
 

--- a/lnd/client.go
+++ b/lnd/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
+	"math"
 	"sync"
 	"time"
 
@@ -223,11 +223,31 @@ func (l *Client) DecodePayreq(payreq string) (paymentHash string, amountMsat uin
 }
 
 func (l *Client) PayInvoice(payreq string) (preImage string, err error) {
-	payres, err := l.lndClient.SendPaymentSync(l.ctx, &lnrpc.SendRequest{PaymentRequest: payreq})
+	_, amountMsat, _, err := l.DecodePayreq(payreq)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
-	return hex.EncodeToString(payres.PaymentPreimage), nil
+	return l.sendPaymentV2(&routerrpc.SendPaymentRequest{
+		PaymentRequest: payreq,
+		TimeoutSeconds: 30,
+		FeeLimitMsat:   defaultPaymentFeeLimitMsat(amountMsat),
+	}, "PayInvoice")
+}
+
+func defaultPaymentFeeLimitMsat(amountMsat uint64) int64 {
+	const smallPaymentMsat = 1_000 * 1_000
+
+	if amountMsat <= smallPaymentMsat {
+		return uint64ToInt64(amountMsat)
+	}
+	return uint64ToInt64(amountMsat / 20)
+}
+
+func uint64ToInt64(value uint64) int64 {
+	if value > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(value)
 }
 
 func (l *Client) CheckChannel(shortChannelId string, amountSat uint64) (*lnrpc.Channel, error) {
@@ -278,8 +298,7 @@ func (l *Client) AddPaymentCallback(f func(swapId string, invoiceType swap.Invoi
 }
 
 // PayInvoiceViaChannel ensures that the invoice is paid via the direct channel
-// to the peer. It takes the desired channel as the enforced route and uses the
-// `SendToRouteSync` api for a direct payment via this route.
+// to the peer. It takes the desired channel as the enforced first hop route.
 func (l *Client) PayInvoiceViaChannel(payreq, scid string) (preimage string, err error) {
 	decoded, err := l.lndClient.DecodePayReq(l.ctx, &lnrpc.PayReqString{PayReq: payreq})
 	if err != nil {
@@ -294,14 +313,17 @@ func (l *Client) PayInvoiceViaChannel(payreq, scid string) (preimage string, err
 		return "", fmt.Errorf(`destination pubkey in invoice does not match remote pubkey of channel. 
 		destination pubkey in invoice: %s, remote pubkey of channel: %s `, decoded.GetDestination(), channel.RemotePubkey)
 	}
-	paymentStream, err := l.routerClient.SendPaymentV2(l.ctx, &routerrpc.SendPaymentRequest{
+	return l.sendPaymentV2(&routerrpc.SendPaymentRequest{
 		PaymentRequest:  payreq,
 		TimeoutSeconds:  30,
 		CltvLimit:       int32(decoded.GetCltvExpiry() + int64(routing.BlockPadding) + 1),
 		OutgoingChanIds: []uint64{channel.ChanId},
 		MaxParts:        1,
-	})
+	}, "PayInvoiceViaChannel")
+}
 
+func (l *Client) sendPaymentV2(req *routerrpc.SendPaymentRequest, operation string) (string, error) {
+	paymentStream, err := l.routerClient.SendPaymentV2(l.ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -312,15 +334,15 @@ func (l *Client) PayInvoiceViaChannel(payreq, scid string) (preimage string, err
 		}
 		switch res.Status {
 		case lnrpc.Payment_UNKNOWN:
-			log.Debugf("PayInvoiceViaChannel: payment is unknown")
+			log.Debugf("%s: payment is unknown", operation)
 		case lnrpc.Payment_SUCCEEDED:
 			return res.PaymentPreimage, nil
 		case lnrpc.Payment_IN_FLIGHT:
-			log.Debugf("PayInvoiceViaChannel: payment still in flight")
+			log.Debugf("%s: payment still in flight", operation)
 		case lnrpc.Payment_FAILED:
 			return "", fmt.Errorf("payment failure %s", res.FailureReason)
 		default:
-			log.Debugf("PayInvoiceViaChannel: got unexpected payment status %d", res.Status)
+			log.Debugf("%s: got unexpected payment status %d", operation, res.Status)
 		}
 		time.Sleep(time.Second)
 	}
@@ -434,16 +456,21 @@ func (l *Client) probePayment(scid string, amountMsat uint64) (bool, string, err
 		return false, "", fmt.Errorf("DecodeString() %w", err)
 	}
 
-	res2, err := l.lndClient.SendToRouteSync(context.Background(), &lnrpc.SendToRouteRequest{
+	attempt, err := l.routerClient.SendToRouteV2(context.Background(), &routerrpc.SendToRouteRequest{
 		PaymentHash: pHash,
 		Route:       route.GetRoute(),
 	})
 	if err != nil {
-		return false, "", fmt.Errorf("SendToRouteSync() %w", err)
+		return false, "", fmt.Errorf("SendToRouteV2() %w", err)
 	}
-	if !strings.Contains(res2.PaymentError, "IncorrectOrUnknownPaymentDetails") {
-		log.Debugf("send pay would be failed. reason:%w", res2.PaymentError)
-		return false, res2.PaymentError, nil
+	failure := attempt.GetFailure()
+	if failure == nil {
+		return false, "probe payment unexpectedly settled", nil
+	}
+	if failure.GetCode() != lnrpc.Failure_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS {
+		failureReason := failure.GetCode().String()
+		log.Debugf("send pay would fail. reason: %s", failureReason)
+		return false, failureReason, nil
 	}
 	return true, "", nil
 }

--- a/testframework/lnd.go
+++ b/testframework/lnd.go
@@ -572,14 +572,31 @@ func (n *LndNode) AddInvoice(amt uint64, desc, _ string) (payreq string, err err
 }
 
 func (n *LndNode) PayInvoice(payreq string) error {
-	pstream, err := n.Rpc.SendPaymentSync(context.Background(), &lnrpc.SendRequest{PaymentRequest: payreq})
+	pstream, err := n.RpcV2.SendPaymentV2(context.Background(), &routerrpc.SendPaymentRequest{
+		PaymentRequest:    payreq,
+		TimeoutSeconds:    30,
+		FeeLimitMsat:      math.MaxInt64,
+		NoInflightUpdates: true,
+	})
 	if err != nil {
 		return err
 	}
-	if len(pstream.PaymentError) > 0 {
-		return fmt.Errorf("got payment error %s", pstream.PaymentError)
+	for {
+		payment, err := pstream.Recv()
+		if err != nil {
+			return err
+		}
+		switch payment.GetStatus() {
+		case lnrpc.Payment_SUCCEEDED:
+			return nil
+		case lnrpc.Payment_FAILED:
+			return fmt.Errorf("got payment error %s", payment.GetFailureReason())
+		case lnrpc.Payment_UNKNOWN, lnrpc.Payment_IN_FLIGHT:
+			time.Sleep(time.Second)
+		default:
+			return fmt.Errorf("got unexpected payment status %s", payment.GetStatus())
+		}
 	}
-	return nil
 }
 
 func (n *LndNode) SendPay(bolt11, _ string) error {


### PR DESCRIPTION
LND 0.21 removes the legacy payment RPCs that PeerSwap still used in the LND payment and probe paths. That makes swaps fail against upgraded LND nodes even though the repository still builds against the older Go module stubs, so this updates those flows to the supported router V2 APIs.

The branch also keeps the Nix runtime update that exposed the incompatibility and adds an early CI guard for the removed LND RPCs. That turns future automated flake updates into a clearer compatibility signal before the full daemon matrix has to surface the same class of server-side API drift.

Fixes #448.
Related #445.
Supersedes #434.
