### PR TITLE
Prevent swap-out prepayment loss on opening tx failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ test-matrix-liquid_lndlnd: test-bins
 # Consolidated misc tests including CLN/LND-specific invariants and setup checks
 .PHONY: test-matrix-misc
 test-matrix-misc: test-bins
-	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_OnlyOneActiveSwapPerChannelCln|Test_OnlyOneActiveSwapPerChannelLnd|Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnConfig|Test_ClnPluginConfigFile|Test_ClnPluginConfigFile_DoesNotExist|Test_ClnPluginConfig_ElementsAuthCookie|Test_ClnPluginConfig_DisableLiquid|Test_CLNLiquidSetup|Test_ClnCln_ExcessiveAmount|Test_ClnCln_StuckChannels|Test_LndLnd_ExcessiveAmount|Test_Wumbo|Test_Cln_HtlcMaximum|Test_Cln_Premium|Test_Cln_shutdown|Test_ClnCln_Poll|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck)$$' ./test
+	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_OnlyOneActiveSwapPerChannelCln|Test_OnlyOneActiveSwapPerChannelLnd|Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnConfig|Test_ClnPluginConfigFile|Test_ClnPluginConfigFile_DoesNotExist|Test_ClnPluginConfig_ElementsAuthCookie|Test_ClnPluginConfig_DisableLiquid|Test_CLNLiquidSetup|Test_ClnCln_ExcessiveAmount|Test_ClnCln_StuckChannels|Test_LndLnd_ExcessiveAmount|Test_Wumbo|Test_Cln_HtlcMaximum|Test_Cln_Premium|Test_Cln_shutdown|Test_ClnCln_Poll|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck|Test_ClnCln_ElementsSwapOutPrecheckLockedWallet)$$' ./test
 
 # Sharded misc tests to reduce single-job runtime in CI
 .PHONY: test-matrix-misc_1
@@ -203,7 +203,7 @@ test-matrix-misc_1: test-bins
 
 .PHONY: test-matrix-misc_2
 test-matrix-misc_2: test-bins
-	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck)$$' ./test
+	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck|Test_ClnCln_ElementsSwapOutPrecheckLockedWallet)$$' ./test
 
 .PHONY: test-matrix-misc_3
 test-matrix-misc_3: test-bins

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ test-matrix-liquid_lndlnd: test-bins
 # Consolidated misc tests including CLN/LND-specific invariants and setup checks
 .PHONY: test-matrix-misc
 test-matrix-misc: test-bins
-	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_OnlyOneActiveSwapPerChannelCln|Test_OnlyOneActiveSwapPerChannelLnd|Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnConfig|Test_ClnPluginConfigFile|Test_ClnPluginConfigFile_DoesNotExist|Test_ClnPluginConfig_ElementsAuthCookie|Test_ClnPluginConfig_DisableLiquid|Test_CLNLiquidSetup|Test_ClnCln_ExcessiveAmount|Test_ClnCln_StuckChannels|Test_LndLnd_ExcessiveAmount|Test_Wumbo|Test_Cln_HtlcMaximum|Test_Cln_Premium|Test_Cln_shutdown|Test_ClnCln_Poll)$$' ./test
+	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_OnlyOneActiveSwapPerChannelCln|Test_OnlyOneActiveSwapPerChannelLnd|Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnConfig|Test_ClnPluginConfigFile|Test_ClnPluginConfigFile_DoesNotExist|Test_ClnPluginConfig_ElementsAuthCookie|Test_ClnPluginConfig_DisableLiquid|Test_CLNLiquidSetup|Test_ClnCln_ExcessiveAmount|Test_ClnCln_StuckChannels|Test_LndLnd_ExcessiveAmount|Test_Wumbo|Test_Cln_HtlcMaximum|Test_Cln_Premium|Test_Cln_shutdown|Test_ClnCln_Poll|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck)$$' ./test
 
 # Sharded misc tests to reduce single-job runtime in CI
 .PHONY: test-matrix-misc_1
@@ -203,7 +203,7 @@ test-matrix-misc_1: test-bins
 
 .PHONY: test-matrix-misc_2
 test-matrix-misc_2: test-bins
-	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC)$$' ./test
+	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} -run '^(Test_GrpcReconnectStream|Test_GrpcRetryRequest|Test_RestoreFromPassedCSV|Test_Recover_PassedSwap_BTC|Test_Recover_PassedSwap_LBTC|Test_ClnCln_SwapOutPrecheck|Test_LndLnd_SwapOutPrecheck)$$' ./test
 
 .PHONY: test-matrix-misc_3
 test-matrix-misc_3: test-bins

--- a/clightning/clightning_wallet.go
+++ b/clightning/clightning_wallet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elementsproject/glightning/glightning"
 	"github.com/elementsproject/peerswap/lightning"
+	"github.com/elementsproject/peerswap/log"
 	"github.com/elementsproject/peerswap/onchain"
 	"github.com/elementsproject/peerswap/swap"
 	"github.com/elementsproject/peerswap/version"
@@ -58,6 +59,31 @@ func (cl *ClightningClient) CreateOpeningTransaction(swapParams *swap.OpeningPar
 		return "", "", "", 0, 0, errors.New(fmt.Sprintf("tx was not prepared %v", err))
 	}
 	return sendRes.SignedTx, addr, sendRes.TxId, fee, vout, nil
+}
+
+// PrecheckOpeningTransaction prepares (but never broadcasts) a throwaway
+// opening transaction to verify that the wallet can fund it right now. The
+// input reservation taken by txprepare is released via txdiscard; if the
+// discard fails the reservation expires on its own.
+func (cl *ClightningClient) PrecheckOpeningTransaction(swapParams *swap.OpeningParams) error {
+	addr, err := cl.bitcoinChain.CreateOpeningAddress(swapParams, onchain.BitcoinCsv)
+	if err != nil {
+		return err
+	}
+	outputs := []*glightning.Outputs{
+		{
+			Address: addr,
+			Satoshi: swapParams.Amount,
+		},
+	}
+	prepRes, err := cl.glightning.PrepareTx(outputs, &glightning.FeeRate{Directive: glightning.Urgent}, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := cl.glightning.DiscardTx(prepRes.TxId); err != nil {
+		log.Infof("precheck: txdiscard for %s failed: %v", prepRes.TxId, err)
+	}
+	return nil
 }
 
 func (cl *ClightningClient) CreatePreimageSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams) (txId, txHex, address string, err error) {

--- a/lnd/lnd_wallet.go
+++ b/lnd/lnd_wallet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/elementsproject/peerswap/lightning"
+	"github.com/elementsproject/peerswap/log"
 	"github.com/elementsproject/peerswap/onchain"
 	"github.com/elementsproject/peerswap/swap"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -77,6 +78,47 @@ func (l *Client) CreateOpeningTransaction(swapParams *swap.OpeningParams) (rawTx
 		return "", "", "", 0, 0, err
 	}
 	return rawTxHex, addr, openingTx.TxHash().String(), fee, vout, nil
+}
+
+// PrecheckOpeningTransaction funds and signs (but never broadcasts) a
+// throwaway opening transaction to verify that the wallet can construct it
+// right now. Utxos leased by FundPsbt are released before returning; if a
+// release fails the lease expires on its own after the lnd default lock
+// duration.
+func (l *Client) PrecheckOpeningTransaction(swapParams *swap.OpeningParams) error {
+	addr, err := l.bitcoinOnChain.CreateOpeningAddress(swapParams, onchain.BitcoinCsv)
+	if err != nil {
+		return err
+	}
+
+	fundPsbtTemplate := &walletrpc.TxTemplate{
+		Outputs: map[string]uint64{
+			addr: swapParams.Amount,
+		},
+	}
+	fundRes, err := l.walletClient.FundPsbt(l.ctx, &walletrpc.FundPsbtRequest{
+		Template: &walletrpc.FundPsbtRequest_Raw{Raw: fundPsbtTemplate},
+		Fees:     &walletrpc.FundPsbtRequest_TargetConf{TargetConf: 3},
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, lease := range fundRes.LockedUtxos {
+			_, rerr := l.walletClient.ReleaseOutput(l.ctx, &walletrpc.ReleaseOutputRequest{
+				Id:       lease.Id,
+				Outpoint: lease.Outpoint,
+			})
+			if rerr != nil {
+				log.Infof("precheck: could not release utxo lease: %v", rerr)
+			}
+		}
+	}()
+
+	_, err = l.walletClient.FinalizePsbt(l.ctx, &walletrpc.FinalizePsbtRequest{
+		FundedPsbt: fundRes.FundedPsbt,
+	})
+	return err
 }
 
 func (l *Client) CreatePreimageSpendingTransaction(swapParams *swap.OpeningParams, claimParams *swap.ClaimParams) (string, string, string, error) {

--- a/lwk/lwkwallet.go
+++ b/lwk/lwkwallet.go
@@ -197,6 +197,36 @@ func (r *LWKRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.OpeningPar
 	return broadcasted.Txid, hex, 0, nil
 }
 
+// PrecheckTransaction funds and signs (but never broadcasts) a throwaway
+// version of the opening transaction to verify that the wallet can construct
+// it right now.
+func (r *LWKRpcWallet) PrecheckTransaction(swapParams *swap.OpeningParams, _ []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultContextTimeout)
+	defer cancel()
+	feerate := r.getFeeSatPerVByte(ctx).getValue() * kb
+	fundedTx, err := r.lwkClient.send(ctx, &sendRequest{
+		Addressees: []*unvalidatedAddressee{
+			{
+				Address: swapParams.OpeningAddress,
+				Satoshi: swapParams.Amount,
+			},
+		},
+		WalletName:       r.c.GetWalletName(),
+		FeeRate:          &feerate,
+		EnableCtDiscount: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fund transaction: %w", err)
+	}
+	if _, err := r.lwkClient.sign(ctx, &signRequest{
+		SignerName: r.c.GetSignerName(),
+		Pset:       fundedTx.Pset,
+	}); err != nil {
+		return fmt.Errorf("failed to sign transaction: %w", err)
+	}
+	return nil
+}
+
 // GetBalance returns the balance in sats
 func (r *LWKRpcWallet) GetBalance() (Satoshi, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultContextTimeout)

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -58,16 +58,7 @@ func (l *LiquidOnChain) GetOnchainBalance() (uint64, error) {
 }
 
 func (l *LiquidOnChain) CreateOpeningTransaction(swapParams *swap.OpeningParams) (txHex, address, txid string, fee uint64, vout uint32, err error) {
-	redeemScript, err := ParamsToTxScript(swapParams, LiquidCsv)
-	if err != nil {
-		return "", "", "", 0, 0, err
-	}
-	scriptPubKey := []byte{0x00, 0x20}
-	witnessProgram := sha256.Sum256(redeemScript)
-	scriptPubKey = append(scriptPubKey, witnessProgram[:]...)
-
-	redeemPayment, _ := payment.FromScript(scriptPubKey, l.network, swapParams.BlindingKey.PubKey())
-	blindedScriptAddr, err := redeemPayment.ConfidentialWitnessScriptHash()
+	blindedScriptAddr, err := l.deriveOpeningAddress(swapParams)
 	if err != nil {
 		return "", "", "", 0, 0, err
 	}
@@ -77,6 +68,33 @@ func (l *LiquidOnChain) CreateOpeningTransaction(swapParams *swap.OpeningParams)
 		return "", "", "", 0, 0, err
 	}
 	return txHex, blindedScriptAddr, txId, fee, vout, nil
+}
+
+// PrecheckOpeningTransaction funds and signs (but never broadcasts) a
+// throwaway opening transaction to verify that the wallet can construct it
+// right now.
+func (l *LiquidOnChain) PrecheckOpeningTransaction(swapParams *swap.OpeningParams) error {
+	blindedScriptAddr, err := l.deriveOpeningAddress(swapParams)
+	if err != nil {
+		return err
+	}
+	swapParams.OpeningAddress = blindedScriptAddr
+	return l.liquidWallet.PrecheckTransaction(swapParams, l.asset)
+}
+
+// deriveOpeningAddress computes the confidential p2wsh address of the
+// opening output for the given swap params.
+func (l *LiquidOnChain) deriveOpeningAddress(swapParams *swap.OpeningParams) (string, error) {
+	redeemScript, err := ParamsToTxScript(swapParams, LiquidCsv)
+	if err != nil {
+		return "", err
+	}
+	scriptPubKey := []byte{0x00, 0x20}
+	witnessProgram := sha256.Sum256(redeemScript)
+	scriptPubKey = append(scriptPubKey, witnessProgram[:]...)
+
+	redeemPayment, _ := payment.FromScript(scriptPubKey, l.network, swapParams.BlindingKey.PubKey())
+	return redeemPayment.ConfidentialWitnessScriptHash()
 }
 
 // feeAmountPlaceholder is a placeholder for the fee amount

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -936,3 +936,23 @@ func (c *AddSuspiciousPeerAction) Execute(services *SwapServices, swap *SwapData
 	log.Infof("added peer %s to suspicious peer list", swap.PeerNodeId)
 	return c.next.Execute(services, swap)
 }
+
+// AddSuspiciousPeerOnPrepaymentLossAction adds the peer to the suspicious
+// peer list iff the swap-out sender paid the prepayment (fee invoice) and
+// the peer then canceled before broadcasting the opening transaction, i.e.
+// the prepayment is lost (issue #324). All other cancel paths pass through
+// untouched.
+type AddSuspiciousPeerOnPrepaymentLossAction struct {
+	next Action
+}
+
+func (c *AddSuspiciousPeerOnPrepaymentLossAction) Execute(services *SwapServices, swap *SwapData) EventType {
+	if swap.FeePreimage != "" && swap.OpeningTxBroadcasted == nil && swap.Cancel != nil {
+		if err := services.policy.AddToSuspiciousPeerList(swap.PeerNodeId); err != nil {
+			log.Infof("error adding peer %s to suspicious peer list: %v", swap.PeerNodeId, err)
+		} else {
+			log.Infof("added peer %s to suspicious peer list: peer canceled swap-out after the prepayment was paid", swap.PeerNodeId)
+		}
+	}
+	return c.next.Execute(services, swap)
+}

--- a/swap/actions.go
+++ b/swap/actions.go
@@ -423,6 +423,34 @@ func (c *CreateSwapOutFromRequestAction) Execute(services *SwapServices, swap *S
 		return swap.HandleError(errors.New("insufficient walletbalance"))
 	}
 
+	// Dry-run the opening transaction (fund and sign, but never broadcast)
+	// so that wallet problems like a locked wallet or unspendable coins
+	// cancel the swap before the peer pays the fee invoice (issue #324).
+	// The payment hash is a placeholder as the claim preimage does not
+	// exist yet; it only shapes the never-broadcast output script.
+	var blindingKey *btcec.PrivateKey
+	if swap.GetChain() == l_btc_chain {
+		blindingKeyBytes, err := hex.DecodeString(swap.BlindingKeyHex)
+		if err != nil {
+			return swap.HandleError(err)
+		}
+		blindingKey, _ = btcec.PrivKeyFromBytes(blindingKeyBytes)
+	}
+	dummyPreimage, err := lightning.GetPreimage()
+	if err != nil {
+		return swap.HandleError(err)
+	}
+	err = wallet.PrecheckOpeningTransaction(&OpeningParams{
+		TakerPubkey:      swap.GetTakerPubkey(),
+		MakerPubkey:      hex.EncodeToString(swap.GetPrivkey().PubKey().SerializeCompressed()),
+		ClaimPaymentHash: dummyPreimage.Hash().String(),
+		Amount:           swap.GetOpeningTXAmount(),
+		BlindingKey:      blindingKey,
+	})
+	if err != nil {
+		return swap.HandleError(fmt.Errorf("opening transaction precheck failed: %v", err))
+	}
+
 	// Construct memo
 	memo := fmt.Sprintf("peerswap %s %s %s %s", swap.GetChain(), INVOICE_FEE, swap.GetScidInBoltFormat(), swap.GetId())
 

--- a/swap/services.go
+++ b/swap/services.go
@@ -73,6 +73,12 @@ type Validator interface {
 type Wallet interface {
 	SetLabel(txID, address, label string) error
 	CreateOpeningTransaction(swapParams *OpeningParams) (unpreparedTxHex, address, txid string, fee uint64, vout uint32, err error)
+	// PrecheckOpeningTransaction funds and signs (but never broadcasts) a
+	// throwaway opening transaction to verify that the wallet can construct
+	// it right now, e.g. that it is not locked and has enough spendable
+	// coins. Any inputs reserved during the check are released before
+	// returning.
+	PrecheckOpeningTransaction(swapParams *OpeningParams) error
 	CreatePreimageSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams) (txId, txHex, address string, err error)
 	CreateCsvSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams) (txId, txHex, address string, error error)
 	CreateCoopSpendingTransaction(swapParams *OpeningParams, claimParams *ClaimParams, takerSigner Signer) (txId, txHex, address string, error error)

--- a/swap/swap_out_receiver_test.go
+++ b/swap/swap_out_receiver_test.go
@@ -1,6 +1,7 @@
 package swap
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -33,6 +34,12 @@ func Test_SwapOutReceiverValidSwap(t *testing.T) {
 	assert.Equal(t, peer, swapFSM.Data.InitiatorNodeId)
 	assert.NotEqual(t, "", swapFSM.Data.SwapOutRequest.Pubkey)
 	assert.NotEqual(t, "", swapFSM.Data.SwapOutAgreement.Pubkey)
+
+	// The opening transaction was prechecked before the fee invoice was sent.
+	bitcoinWallet := swapServices.bitcoinWallet.(*dummyChain)
+	assert.EqualValues(t, 1, bitcoinWallet.precheckOpeningTxCalled)
+	assert.Equal(t, swapAmount, bitcoinWallet.precheckOpeningTxParams.Amount)
+	assert.Equal(t, takerPubkeyHash, bitcoinWallet.precheckOpeningTxParams.TakerPubkey)
 
 	_, err = swapFSM.SendEvent(Event_OnFeeInvoicePaid, nil)
 	if err != nil {
@@ -181,6 +188,43 @@ func Test_SwapOutReceiverInsufficientBalance(t *testing.T) {
 	assert.Equal(t, messages.MESSAGETYPE_CANCELED, msg.MessageType())
 	assert.Equal(t, State_SwapCanceled, swapFSM.Data.GetCurrentState())
 
+}
+
+// Test_SwapOutReceiver_PrecheckFailed checks that the swap is canceled before
+// the fee invoice is sent if the opening transaction precheck fails, so that
+// the peer never pays a prepayment for a swap that can not be performed.
+func Test_SwapOutReceiver_PrecheckFailed(t *testing.T) {
+	swapAmount := uint64(100000)
+	swapId := NewSwapId()
+	_, peer, takerPubkeyHash, _, chanId := getTestParams()
+
+	msgChan := make(chan PeerMessage)
+
+	swapServices := getSwapServices(t, msgChan)
+	swapServices.bitcoinWallet.(*dummyChain).precheckOpeningTxErr =
+		errors.New("wallet couldn't fund PSBT: insufficient funds available to construct transaction")
+
+	swapFSM := newSwapOutReceiverFSM(swapId, swapServices, peer)
+
+	_, err := swapFSM.SendEvent(Event_OnSwapOutRequestReceived, &SwapOutRequestMessage{
+		Amount:          swapAmount,
+		Scid:            chanId,
+		SwapId:          swapId,
+		Pubkey:          takerPubkeyHash,
+		Network:         "mainnet",
+		ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No fee invoice was created; the only message sent to the peer is the
+	// cancel with the precheck failure as the reason.
+	assert.Nil(t, swapFSM.Data.SwapOutAgreement)
+	msg := <-msgChan
+	assert.Equal(t, messages.MESSAGETYPE_CANCELED, msg.MessageType())
+	assert.Equal(t, State_SwapCanceled, swapFSM.Data.GetCurrentState())
+	assert.Contains(t, swapFSM.Data.GetCancelMessage(), "opening transaction precheck failed")
 }
 
 // Test_SwapOutReceiver_PeerIsSuspicious checks that a swap request is rejected

--- a/swap/swap_out_sender.go
+++ b/swap/swap_out_sender.go
@@ -124,7 +124,7 @@ func getSwapOutSenderStates() States {
 			},
 		},
 		State_SwapCanceled: {
-			Action: &CancelAction{},
+			Action: &AddSuspiciousPeerOnPrepaymentLossAction{next: &CancelAction{}},
 		},
 		State_ClaimedPreimage: {
 			Action: &NoOpDoneAction{},

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -416,6 +416,10 @@ type dummyChain struct {
 
 	calledGetCSVHeight int64
 	returnGetCSVHeight uint32
+
+	precheckOpeningTxCalled int64
+	precheckOpeningTxParams *OpeningParams
+	precheckOpeningTxErr    error
 }
 
 func (d *dummyChain) StartWatchingTxs() error {
@@ -491,6 +495,12 @@ func (d *dummyChain) GetFlatOpeningTXFee() (uint64, error) {
 
 func (d *dummyChain) CreateOpeningTransaction(swapParams *OpeningParams) (unpreparedTxHex, address, txid string, fee uint64, vout uint32, err error) {
 	return "txhex", "address", getRandom32ByteHexString(), 0, 0, nil
+}
+
+func (d *dummyChain) PrecheckOpeningTransaction(swapParams *OpeningParams) error {
+	d.precheckOpeningTxCalled++
+	d.precheckOpeningTxParams = swapParams
+	return d.precheckOpeningTxErr
 }
 
 func (d *dummyChain) AddCsvCallback(f func(swapId string) error) {

--- a/swap/swap_out_sender_test.go
+++ b/swap/swap_out_sender_test.go
@@ -149,6 +149,96 @@ func Test_Cancel1(t *testing.T) {
 	msg = <-msgChan
 	assert.Equal(t, messages.MESSAGETYPE_CANCELED, msg.MessageType())
 	assert.Equal(t, State_SwapCanceled, swapFSM.Data.GetCurrentState())
+	// A swap we canceled ourselves does not mark the peer as suspicious.
+	assert.Equal(t, 0, swapServices.policy.(*dummyPolicy).addToSuspiciousPeerListCalled)
+}
+
+// Test_SwapOutSender_CancelAfterPrepaymentAddsSuspiciousPeer checks that the
+// peer is added to the suspicious peer list if it cancels the swap after the
+// fee invoice (prepayment) was paid but before the opening transaction was
+// broadcast, i.e. the prepayment is lost.
+func Test_SwapOutSender_CancelAfterPrepaymentAddsSuspiciousPeer(t *testing.T) {
+	swapAmount := uint64(100000)
+	initiator, peer, takerpubkeyhash, _, chanId := getTestParams()
+	FeeInvoice := "fee"
+	msgChan := make(chan PeerMessage)
+
+	swapServices := getSwapServices(t, msgChan)
+	swapServices.toService = &timeOutDummy{}
+	swapFSM := newSwapOutSenderFSM(swapServices, initiator, peer)
+
+	_, err := swapFSM.SendEvent(Event_OnSwapOutStarted, &SwapOutRequestMessage{
+		Amount:          swapAmount,
+		Scid:            chanId,
+		SwapId:          swapFSM.SwapId,
+		Pubkey:          takerpubkeyhash,
+		Network:         "mainnet",
+		ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
+		PremiumLimit:    10000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = swapFSM.SendEvent(Event_OnFeeInvoiceReceived, &SwapOutAgreementMessage{
+		Payreq:  FeeInvoice,
+		Pubkey:  peer,
+		Premium: 1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, State_SwapOutSender_AwaitTxBroadcastedMessage, swapFSM.Data.GetCurrentState())
+	assert.NotEqual(t, "", swapFSM.Data.FeePreimage)
+
+	_, err = swapFSM.SendEvent(Event_OnCancelReceived, &CancelMessage{
+		SwapId:  swapFSM.SwapId,
+		Message: "opening transaction precheck failed: wallet locked",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, State_SwapCanceled, swapFSM.Data.GetCurrentState())
+
+	pol := swapServices.policy.(*dummyPolicy)
+	assert.Equal(t, 1, pol.addToSuspiciousPeerListCalled)
+	assert.Equal(t, peer, pol.addToSuspiciousPeerListParam)
+}
+
+// Test_SwapOutSender_CancelBeforePrepaymentNotSuspicious checks that a peer
+// that cancels the swap before the fee invoice was paid is not added to the
+// suspicious peer list.
+func Test_SwapOutSender_CancelBeforePrepaymentNotSuspicious(t *testing.T) {
+	swapAmount := uint64(100000)
+	initiator, peer, takerpubkeyhash, _, chanId := getTestParams()
+	msgChan := make(chan PeerMessage)
+
+	swapServices := getSwapServices(t, msgChan)
+	swapFSM := newSwapOutSenderFSM(swapServices, initiator, peer)
+
+	_, err := swapFSM.SendEvent(Event_OnSwapOutStarted, &SwapOutRequestMessage{
+		Amount:          swapAmount,
+		Scid:            chanId,
+		SwapId:          swapFSM.SwapId,
+		Pubkey:          takerpubkeyhash,
+		Network:         "mainnet",
+		ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := <-msgChan
+	assert.Equal(t, messages.MESSAGETYPE_SWAPOUTREQUEST, msg.MessageType())
+
+	_, err = swapFSM.SendEvent(Event_OnCancelReceived, &CancelMessage{
+		SwapId:  swapFSM.SwapId,
+		Message: "no swaps allowed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, State_SwapCanceled, swapFSM.Data.GetCurrentState())
+	assert.Equal(t, 0, swapServices.policy.(*dummyPolicy).addToSuspiciousPeerListCalled)
 }
 
 func Test_AbortCsvClaim(t *testing.T) {
@@ -372,6 +462,9 @@ type dummyPolicy struct {
 
 	newSwapsAllowedCalled int
 	newSwapsAllowedReturn bool
+
+	addToSuspiciousPeerListCalled int
+	addToSuspiciousPeerListParam  string
 }
 
 func (d *dummyPolicy) NewSwapsAllowed() bool {
@@ -393,6 +486,8 @@ func (d *dummyPolicy) IsPeerAllowed(peer string) bool {
 }
 
 func (d *dummyPolicy) AddToSuspiciousPeerList(pubkey string) error {
+	d.addToSuspiciousPeerListCalled++
+	d.addToSuspiciousPeerListParam = pubkey
 	return nil
 }
 

--- a/test/swap_precheck_test.go
+++ b/test/swap_precheck_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -113,6 +114,54 @@ func Test_LndLnd_SwapOutPrecheck(t *testing.T) {
 		Asset:               "btc",
 		PremiumLimitRatePpm: params.premiumLimitRatePPM,
 	})
+	assertError(t, err)
+
+	requireNoError(t, params.makerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+	requireNoError(t, params.takerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+
+	assertNoPrepayment(t, params.takerPeerswap)
+}
+
+// Test_ClnCln_ElementsSwapOutPrecheckLockedWallet checks that the original
+// Elements wallet-lock failure from issue #324 is detected before the taker
+// pays the fee invoice.
+func Test_ClnCln_ElementsSwapOutPrecheckLockedWallet(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(9)))
+	DumpOnFailure(t,
+		WithBitcoin(bitcoind),
+		WithLiquid(liquidd),
+		WithCLightningNodes(lightningds, nil),
+	)
+
+	params := clnLiquidParams(t, liquidd, lightningds, scid, swap.SWAPTYPE_OUT)
+
+	// The second node is the swap-out maker and uses the Elements wallet
+	// named swap2. Encrypting and explicitly locking it reproduces the
+	// signing failure from the original report while leaving its balance
+	// visible to the preliminary balance check.
+	liquidd.UpdateServiceUrl(fmt.Sprintf(
+		"http://127.0.0.1:%d/wallet/swap2",
+		liquidd.RpcPort,
+	))
+	_, err := liquidd.Rpc.Call("encryptwallet", "peerswap-test-passphrase")
+	requireNoError(t, err)
+	_, err = liquidd.Rpc.Call("walletlock")
+	requireNoError(t, err)
+
+	var response map[string]interface{}
+	err = lightningds[0].Rpc.Request(&clightning.SwapOut{
+		SatAmt:              params.swapAmt,
+		ShortChannelId:      params.scid,
+		Asset:               "lbtc",
+		PremiumLimitRatePPM: params.premiumLimitRatePPM,
+	}, &response)
 	assertError(t, err)
 
 	requireNoError(t, params.makerPeerswap.WaitForLog(

--- a/test/swap_precheck_test.go
+++ b/test/swap_precheck_test.go
@@ -1,0 +1,126 @@
+package test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/elementsproject/glightning/glightning"
+	"github.com/elementsproject/peerswap/clightning"
+	"github.com/elementsproject/peerswap/peerswaprpc"
+	"github.com/elementsproject/peerswap/swap"
+	"github.com/elementsproject/peerswap/testframework"
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+// drainClnToUnconfirmed spends all of the node's confirmed onchain coins
+// back to itself without confirming the transaction. The wallet balance
+// still counts the unconfirmed change while coin selection for the opening
+// transaction (minconf=1) can not spend it.
+func drainClnToUnconfirmed(t *testing.T, node *testframework.CLightningNode) {
+	t.Helper()
+
+	addr, err := node.Rpc.NewAddr()
+	requireNoError(t, err)
+
+	_, err = node.Rpc.Withdraw(addr, glightning.AllSats(), nil, nil)
+	requireNoError(t, err)
+}
+
+// drainLndToUnconfirmed spends all of the node's confirmed onchain coins
+// back to itself without confirming the transaction. The wallet balance
+// still counts the unconfirmed change while FundPsbt (min_confs=1) can not
+// spend it.
+func drainLndToUnconfirmed(t *testing.T, node *testframework.LndNode) {
+	t.Helper()
+
+	ctx := context.Background()
+	addr, err := node.Rpc.NewAddress(ctx, &lnrpc.NewAddressRequest{})
+	requireNoError(t, err)
+
+	_, err = node.Rpc.SendCoins(ctx, &lnrpc.SendCoinsRequest{
+		Addr:    addr.Address,
+		SendAll: true,
+	})
+	requireNoError(t, err)
+}
+
+// assertNoPrepayment checks that the taker never paid the fee invoice
+// (prepayment) for the canceled swap.
+func assertNoPrepayment(t *testing.T, takerPeerswap *testframework.DaemonProcess) {
+	t.Helper()
+
+	hasLog, err := takerPeerswap.HasLog("Paid Feeinvoice of")
+	requireNoError(t, err)
+	newAssertions(t).False(hasLog, "taker should not have paid the fee invoice")
+
+	hasLog, err = takerPeerswap.HasLog("Warning: Paid swap-out prepayment")
+	requireNoError(t, err)
+	newAssertions(t).False(hasLog, "taker should not have lost a prepayment")
+}
+
+// Test_ClnCln_SwapOutPrecheck checks that a swap out is canceled before the
+// taker pays the fee invoice when the maker can not fund the opening
+// transaction, even though its flat wallet balance is sufficient (issue
+// #324). The maker's coins are made unspendable by draining them into an
+// unconfirmed change output.
+func Test_ClnCln_SwapOutPrecheck(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	bitcoind, lightningds, scid := clnclnSetup(t, uint64(math.Pow10(9)))
+	DumpOnFailure(t, WithBitcoin(bitcoind), WithCLightnings(lightningds))
+
+	params := clnParams(t, bitcoind, lightningds, scid, swap.SWAPTYPE_OUT)
+
+	drainClnToUnconfirmed(t, lightningds[1])
+
+	var response map[string]interface{}
+	err := lightningds[0].Rpc.Request(&clightning.SwapOut{
+		SatAmt:              params.swapAmt,
+		ShortChannelId:      params.scid,
+		Asset:               "btc",
+		PremiumLimitRatePPM: params.premiumLimitRatePPM,
+	}, &response)
+	assertError(t, err)
+
+	requireNoError(t, params.makerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+	requireNoError(t, params.takerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+
+	assertNoPrepayment(t, params.takerPeerswap)
+}
+
+// Test_LndLnd_SwapOutPrecheck is the lnd variant of
+// Test_ClnCln_SwapOutPrecheck.
+func Test_LndLnd_SwapOutPrecheck(t *testing.T) {
+	IsIntegrationTest(t)
+	t.Parallel()
+
+	bitcoind, lightningds, peerswapds, scid := lndlndSetup(t, lndFundAmount)
+	DumpOnFailure(t, WithBitcoin(bitcoind), WithLnds(lightningds), WithPeerSwapds(peerswapds...))
+
+	params, channelID := lndParams(t, bitcoind, lightningds, peerswapds, scid, swap.SWAPTYPE_OUT)
+
+	drainLndToUnconfirmed(t, lightningds[1])
+
+	_, err := peerswapds[0].PeerswapClient.SwapOut(context.Background(), &peerswaprpc.SwapOutRequest{
+		ChannelId:           channelID,
+		SwapAmount:          params.swapAmt,
+		Asset:               "btc",
+		PremiumLimitRatePpm: params.premiumLimitRatePPM,
+	})
+	assertError(t, err)
+
+	requireNoError(t, params.makerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+	requireNoError(t, params.takerPeerswap.WaitForLog(
+		"Swap canceled. Reason: opening transaction precheck failed",
+		testframework.TIMEOUT))
+
+	assertNoPrepayment(t, params.takerPeerswap)
+}

--- a/wallet/elementsrpcwallet.go
+++ b/wallet/elementsrpcwallet.go
@@ -75,16 +75,16 @@ func (r *ElementsRpcWallet) FinalizeTransaction(rawTx string) (string, error) {
 	return finalized.Hex, nil
 }
 
-// CreateAndBroadcastTransaction takes a tx with outputs and adds inputs in order to spend the tx
-func (r *ElementsRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.OpeningParams,
-	asset []byte) (txid, rawTx string, fee uint64, err error) {
+// buildOpeningTxTemplate builds the raw transaction template holding the
+// single blinded opening output that funding is based on.
+func buildOpeningTxTemplate(swapParams *swap.OpeningParams, asset []byte) (string, error) {
 	outputscript, err := address.ToOutputScript(swapParams.OpeningAddress)
 	if err != nil {
-		return "", "", 0, err
+		return "", err
 	}
 	sats, err := elementsutil.ValueToBytes(swapParams.Amount)
 	if err != nil {
-		return "", "", 0, err
+		return "", err
 	}
 	output := transaction.NewTxOutput(asset, sats, outputscript)
 	output.Nonce = swapParams.BlindingKey.PubKey().SerializeCompressed()
@@ -92,24 +92,39 @@ func (r *ElementsRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.Openi
 	tx := transaction.NewTx(2)
 	tx.Outputs = append(tx.Outputs, output)
 
-	txHex, err := tx.ToHex()
-	if err != nil {
-		return "", "", 0, err
-	}
+	return tx.ToHex()
+}
+
+// fundAndFinalizeTransaction funds, blinds and signs the given tx template
+// and returns the finalized tx along with the funding result.
+func (r *ElementsRpcWallet) fundAndFinalizeTransaction(txHex string) (finalized string, fundedTx *gelements.FundRawResult, err error) {
 	feerate, err := r.getFeeRate()
 	if err != nil {
-		return "", "", 0, err
+		return "", nil, err
 	}
 	// Round BTC/kB to nearest sat/kB so the string format is exact
 	satPerKb := uint64(math.Round(feerate * satsPerBTC))
-	fundedTx, err := r.rpcClient.FundRawWithOptions(txHex, &gelements.FundRawOptions{
+	fundedTx, err = r.rpcClient.FundRawWithOptions(txHex, &gelements.FundRawOptions{
 		FeeRate: SatsToBTCString(satPerKb),
 	}, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	finalized, err = r.FinalizeTransaction(fundedTx.TxString)
+	if err != nil {
+		return "", nil, err
+	}
+	return finalized, fundedTx, nil
+}
 
+// CreateAndBroadcastTransaction takes a tx with outputs and adds inputs in order to spend the tx
+func (r *ElementsRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.OpeningParams,
+	asset []byte) (txid, rawTx string, fee uint64, err error) {
+	txHex, err := buildOpeningTxTemplate(swapParams, asset)
 	if err != nil {
 		return "", "", 0, err
 	}
-	finalized, err := r.FinalizeTransaction(fundedTx.TxString)
+	finalized, fundedTx, err := r.fundAndFinalizeTransaction(txHex)
 	if err != nil {
 		return "", "", 0, err
 	}
@@ -118,6 +133,20 @@ func (r *ElementsRpcWallet) CreateAndBroadcastTransaction(swapParams *swap.Openi
 		return "", "", 0, err
 	}
 	return txid, finalized, gelements.ConvertBtc(fundedTx.Fee), nil
+}
+
+// PrecheckTransaction funds, blinds and signs (but never broadcasts) a
+// throwaway version of the opening transaction to verify that the wallet can
+// construct it right now, e.g. that it is not locked and has enough
+// spendable coins. FundRawWithOptions does not lock the selected utxos, so
+// there is nothing to release afterwards.
+func (r *ElementsRpcWallet) PrecheckTransaction(swapParams *swap.OpeningParams, asset []byte) error {
+	txHex, err := buildOpeningTxTemplate(swapParams, asset)
+	if err != nil {
+		return err
+	}
+	_, _, err = r.fundAndFinalizeTransaction(txHex)
+	return err
 }
 
 // setupWallet checks if the swap wallet is already loaded in elementsd, if not it loads/creates it

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -20,6 +20,10 @@ type Wallet interface {
 	SendToAddress(string, uint64) (string, error)
 	GetBalance() (uint64, error)
 	CreateAndBroadcastTransaction(swapParams *swap.OpeningParams, asset []byte) (txid, rawTx string, fee uint64, err error)
+	// PrecheckTransaction funds and signs (but never broadcasts) a throwaway
+	// version of the opening transaction to verify that the wallet can
+	// construct it right now.
+	PrecheckTransaction(swapParams *swap.OpeningParams, asset []byte) error
 	SendRawTx(rawTx string) (txid string, err error)
 	GetFee(txSize int64) (uint64, error)
 	SetLabel(txID, address, label string) error


### PR DESCRIPTION
Fixes #324

In a swap out, the taker pays the fee invoice (prepayment) before the maker constructs the opening transaction. If the maker's wallet cannot fund or sign the transaction at that point (locked wallet, `insufficient funds to fund PSBT`, unspendable coins), the swap is canceled after the prepayment was already paid, and the taker loses it.

### Maker side: dry-run precheck before sending the fee invoice

When a swap-out request is received, the maker now funds and signs a throwaway opening transaction — without broadcasting it — before creating the fee invoice. If this fails, the swap is canceled before the taker pays anything. Implemented for all wallet backends:

- LND: `FundPsbt` + `FinalizePsbt`; utxo leases are released afterwards
- CLN: `txprepare` + `txdiscard`
- Elements: `fundrawtransaction` + blind + sign (utxos are not locked)
- LWK: build + sign the PSET, skip the broadcast

`testmempoolaccept` (the second proposal in the issue) was left out: LND and CLN expose no equivalent API, and the fund+sign dry run already catches the failure classes reported in the issue.

### Taker side: flag peers after a prepayment loss

If a peer cancels after the fee invoice was paid but before the opening transaction was broadcast — the exact loss scenario of the issue — the peer is added to the suspicious peer list. Since outgoing swaps to suspicious peers are already refused, an automated setup loses at most one prepayment per misbehaving peer instead of one per attempt. `removesuspiciouspeer` undoes the entry.