### PR TITLE
onchain: Accept explicit Liquid opening assets

### DIFF
--- a/docs/peer-protocol.md
+++ b/docs/peer-protocol.md
@@ -49,7 +49,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
       - [The `claim_by_csv` path](#the-claim_by_csv-path)
 
 ## General
-The `protocol_version` is included to allow for possible changes in the future. The `protocol_version` of this document is `5`.
+The `protocol_version` is included to allow for possible changes in the future. The `protocol_version` of this document is `6`.
 
 PeerSwap utilizes custom messages as described in [BOLT#1](https://github.com/Lightning/bolts/blob/master/01-messaging.md). The types are in range `42069`-`42085`. The `payload` is JSON encoded.
 

--- a/onchain/liquid.go
+++ b/onchain/liquid.go
@@ -489,17 +489,28 @@ func (l *LiquidOnChain) validateOpeningOutput(
 		)
 	}
 
-	assetCommitment, err := confidential.AssetCommitment(
-		unblinded.Asset, unblinded.AssetBlindingFactor,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to reconstruct asset commitment: %w", err)
-	}
-	if !bytes.Equal(assetCommitment, output.Asset) {
-		return nil, fmt.Errorf(
-			"invalid asset commitment got: %x, expected %x",
-			output.Asset, assetCommitment,
+	if !output.IsConfidential() {
+		if !bytes.Equal(output.Asset, l.asset) {
+			return nil, fmt.Errorf(
+				"invalid explicit asset got: %x, expected %x",
+				output.Asset, l.asset,
+			)
+		}
+	} else {
+		assetCommitment, err := confidential.AssetCommitment(
+			unblinded.Asset, unblinded.AssetBlindingFactor,
 		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to reconstruct asset commitment: %w", err,
+			)
+		}
+		if !bytes.Equal(assetCommitment, output.Asset) {
+			return nil, fmt.Errorf(
+				"invalid asset commitment got: %x, expected %x",
+				output.Asset, assetCommitment,
+			)
+		}
 	}
 
 	if unblinded.Value != expectedAmount {

--- a/onchain/liquid_test.go
+++ b/onchain/liquid_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/elementsproject/peerswap/swap"
 	"github.com/vulpemventures/go-elements/confidential"
+	"github.com/vulpemventures/go-elements/elementsutil"
 	"github.com/vulpemventures/go-elements/network"
+	"github.com/vulpemventures/go-elements/payment"
 	"github.com/vulpemventures/go-elements/transaction"
 	secp256k1 "github.com/vulpemventures/go-secp256k1-zkp"
 )
@@ -130,6 +132,11 @@ func TestLiquidOpeningOutputValidation(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("explicit policy asset", func(t *testing.T) {
+		txHex := newExplicitOpeningTx(t, liquidOnChain, openingParams)
+		assertOpeningTransactionAccepted(t, liquidOnChain, openingParams, txHex)
+	})
 }
 
 func newLiquidOpeningParams(t *testing.T) *swap.OpeningParams {
@@ -208,6 +215,94 @@ func newBlindedOpeningTx(
 	checkNoError(t, err)
 
 	return txHex
+}
+
+func assertOpeningTransactionAccepted(
+	t *testing.T,
+	liquidOnChain *LiquidOnChain,
+	openingParams *swap.OpeningParams,
+	openingTxHex string,
+) {
+	t.Helper()
+
+	valid, err := liquidOnChain.ValidateTx(openingParams, openingTxHex)
+	checkNoError(t, err)
+	if !valid {
+		t.Fatal("ValidateTx() = false, want true")
+	}
+
+	assertCsvSpendingTransactionAccepted(
+		t, liquidOnChain, openingParams, openingTxHex,
+	)
+}
+
+func newExplicitOpeningTx(
+	t *testing.T,
+	liquidOnChain *LiquidOnChain,
+	openingParams *swap.OpeningParams,
+) string {
+	t.Helper()
+
+	value, err := elementsutil.ValueToBytes(openingParams.Amount)
+	checkNoError(t, err)
+	outputScript, err := liquidOnChain.GetOutputScript(openingParams)
+	checkNoError(t, err)
+
+	openingTx := transaction.NewTx(2)
+	openingTx.AddInput(transaction.NewTxInput(make([]byte, 32), 0))
+	openingTx.AddOutput(transaction.NewTxOutput(
+		liquidOnChain.asset, value, outputScript,
+	))
+	txHex, err := openingTx.ToHex()
+	checkNoError(t, err)
+
+	return txHex
+}
+
+func assertCsvSpendingTransactionAccepted(
+	t *testing.T,
+	liquidOnChain *LiquidOnChain,
+	openingParams *swap.OpeningParams,
+	openingTxHex string,
+) {
+	t.Helper()
+
+	redeemScript, err := ParamsToTxScript(openingParams, LiquidCsv)
+	checkNoError(t, err)
+	receiverKey, err := btcec.NewPrivateKey()
+	checkNoError(t, err)
+	receiverBlindingKey, err := btcec.NewPrivateKey()
+	checkNoError(t, err)
+	receiverPayment := payment.FromPublicKey(
+		receiverKey.PubKey(),
+		liquidOnChain.network,
+		receiverBlindingKey.PubKey(),
+	)
+	receiverAddress, err := receiverPayment.ConfidentialWitnessPubKeyHash()
+	checkNoError(t, err)
+	ephemeralKey, err := btcec.NewPrivateKey()
+	checkNoError(t, err)
+
+	tx, _, err := liquidOnChain.createSpendingTransaction(
+		openingTxHex,
+		openingParams.Amount,
+		LiquidCsv,
+		liquidOnChain.asset,
+		redeemScript,
+		receiverAddress,
+		100,
+		openingParams.BlindingKey,
+		ephemeralKey,
+		testScalar(5),
+		testScalar(6),
+	)
+	checkNoError(t, err)
+	if tx == nil {
+		t.Fatal("createSpendingTransaction() returned a nil transaction")
+	}
+	if got := tx.Inputs[0].Sequence; got != LiquidCsv {
+		t.Fatalf("input sequence = %d, want %d", got, LiquidCsv)
+	}
 }
 
 func assertSpendingTransactionRejected(

--- a/swap/service.go
+++ b/swap/service.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	PEERSWAP_PROTOCOL_VERSION = 5
+	//nolint:revive // Preserve the existing public protocol-version constant.
+	PEERSWAP_PROTOCOL_VERSION = 6
 )
 
 var (


### PR DESCRIPTION
https://github.com/ElementsProject/peerswap/issues/453 occurs when a max-amount swap spends a single explicit UTXO and leaves no change.
This can produce a one-input/one-output opening transaction with an explicit, unblinded L-BTC output.
The v5.0.1 security check incorrectly applies asset commitment verification to this output, rejecting it and also blocking CSV recovery.

Advertise protocol version 6 and update the peer protocol document so version 5 peers fail compatibility checks before starting a swap.