### PR TITLE
peerswapd: make shutdown signal delivery reliable

### DIFF
--- a/cmd/peerswaplnd/peerswapd/main.go
+++ b/cmd/peerswaplnd/peerswapd/main.go
@@ -66,11 +66,11 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	shutdown := make(chan struct{})
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigChan)
 	go func() {
 		defer close(shutdown)
-		defer close(sigChan)
 
 		select {
 		case sig := <-sigChan:


### PR DESCRIPTION
Use a one-element buffered channel for process signals and unregister it with `signal.Stop` during shutdown.

`os/signal.Notify` does not block when delivering a signal, so an unbuffered channel can lose a signal when the receiver is not ready. The channel also should not be closed while it remains registered with `os/signal`, because a later delivery could panic.

This keeps the existing shutdown flow while making signal ownership and delivery safe.

Tested with:

   ` go test ./cmd/peerswaplnd/peerswapd`