### PR TITLE
test(clightning): fix total paid field name

### DIFF
--- a/clightning/clightning_test.go
+++ b/clightning/clightning_test.go
@@ -14,7 +14,7 @@ type DummyPayerWaiter struct {
 	sendPayPartsAndWaitReturn      *glightning.SendPayFields
 	sendPayPartsAndWaitErrorReturn *error
 
-	totalPayed uint64
+	totalPaid uint64
 }
 
 func TestBuildDirectClaimRouteCLTVBoundary(t *testing.T) {
@@ -48,7 +48,7 @@ func (d *DummyPayerWaiter) SendPayPartAndWait(paymentRequest string, bolt11 *gli
 	d.Lock()
 	defer d.Unlock()
 	d.sendPayPartsAndWaitCalled++
-	d.totalPayed += amountMsat
+	d.totalPaid += amountMsat
 
 	if d.sendPayPartsAndWaitErrorReturn != nil {
 		return nil, *d.sendPayPartsAndWaitErrorReturn


### PR DESCRIPTION
Rename the private `DummyPayerWaiter.totalPayed` test field to the grammatically correct `totalPaid` and update its increment site.

This touches test code only and preserves the accumulated amount and all assertions. `go test ./clightning` passes.