### PR TITLE
Disable new L-BTC swaps following the Liquid incident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/test-builds/pscli
 
 # # build output of tools
 tools/bin/
+out/test-builds/peerswap-v7.0.0

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ ${TEST_BIN_DIR}/peerswap:
 	chmod a+x ${TEST_BIN_DIR}/peerswap
 
 # Test section. Has commands for local and ci testing.
+ifeq ($(RUN_INTEGRATION_TESTS),1)
+test: legacy-test-plugin
+endif
 test:
 	PAYMENT_RETRY_TIME=5 go test -tags dev -tags fast_test -race -timeout=10m -v ./...
 .PHONY: test
@@ -213,3 +216,21 @@ test-matrix-misc_3: test-bins
 .PHONY: test-matrix-lnd
 test-matrix-lnd: test-bins
 	${INTEGRATION_TEST_ENV} go test ${INTEGRATION_TEST_OPTS} ./lnd
+
+# Only the recovery integration test uses this historical binary. It starts a
+# contract before upgrading the same data directory to the suspended version.
+.PHONY: legacy-test-plugin
+legacy-test-plugin:
+	@set -eu; \
+	legacy_commit=578c740e8684e2121b6f8343569f262f6bd69f12; \
+	if ! git cat-file -e "$$legacy_commit^{commit}" 2>/dev/null; then \
+		git fetch origin tag v7.0.0; \
+	fi; \
+	legacy_source=$$(mktemp -d); \
+	trap 'rm -rf "$$legacy_source"' EXIT; \
+	git archive "$$legacy_commit" | tar -x -C "$$legacy_source"; \
+	mkdir -p "$(CURDIR)/$(TEST_BIN_DIR)"; \
+	cd "$$legacy_source"; \
+	go build -tags 'dev fast_test' -o "$(CURDIR)/$(TEST_BIN_DIR)/peerswap-v7.0.0" ./cmd/peerswap-plugin
+
+test-matrix-misc test-matrix-misc_2: legacy-test-plugin

--- a/clightning/clightning_commands.go
+++ b/clightning/clightning_commands.go
@@ -23,6 +23,8 @@ import (
 	"github.com/elementsproject/peerswap/swap"
 )
 
+const liquidAsset = "lbtc"
+
 type SwapCanceledError string
 
 func (e SwapCanceledError) Error() string {
@@ -194,6 +196,9 @@ func (l *SwapOut) Name() string {
 }
 
 func (l *SwapOut) Call() (jrpc2.Result, error) {
+	if l.Asset == liquidAsset {
+		return nil, swap.ErrNewLiquidSwapsDisabled
+	}
 	if !l.cl.isReady {
 		return nil, ErrWaitingForReady
 	}
@@ -316,6 +321,9 @@ func (l *SwapIn) Name() string {
 }
 
 func (l *SwapIn) Call() (jrpc2.Result, error) {
+	if l.Asset == liquidAsset {
+		return nil, swap.ErrNewLiquidSwapsDisabled
+	}
 	if !l.cl.isReady {
 		return nil, ErrWaitingForReady
 	}

--- a/clightning/liquid_suspension_test.go
+++ b/clightning/liquid_suspension_test.go
@@ -1,0 +1,22 @@
+package clightning
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elementsproject/peerswap/swap"
+)
+
+func TestLiquidSuspensionBeforeBackendAccess(t *testing.T) {
+	// No CLN client or wallet: rejection must work even when the backend is down.
+	for _, force := range []bool{false, true} {
+		_, err := (&SwapIn{Asset: liquidAsset, Force: force}).Call()
+		if !errors.Is(err, swap.ErrNewLiquidSwapsDisabled) {
+			t.Fatalf("swap-in: %v", err)
+		}
+		_, err = (&SwapOut{Asset: liquidAsset, Force: force}).Call()
+		if !errors.Is(err, swap.ErrNewLiquidSwapsDisabled) {
+			t.Fatalf("swap-out: %v", err)
+		}
+	}
+}

--- a/peerswaprpc/liquid_suspension_test.go
+++ b/peerswaprpc/liquid_suspension_test.go
@@ -1,0 +1,24 @@
+package peerswaprpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elementsproject/peerswap/swap"
+)
+
+func TestLiquidSuspensionBeforeBackendAccess(t *testing.T) {
+	// No LND client or wallet: rejection must not require a healthy backend.
+	server := &PeerswapServer{}
+	for _, force := range []bool{false, true} {
+		_, err := server.SwapIn(context.Background(), &SwapInRequest{Asset: liquidAsset, Force: force})
+		if !errors.Is(err, swap.ErrNewLiquidSwapsDisabled) {
+			t.Fatalf("swap-in: %v", err)
+		}
+		_, err = server.SwapOut(context.Background(), &SwapOutRequest{Asset: liquidAsset, Force: force})
+		if !errors.Is(err, swap.ErrNewLiquidSwapsDisabled) {
+			t.Fatalf("swap-out: %v", err)
+		}
+	}
+}

--- a/peerswaprpc/server.go
+++ b/peerswaprpc/server.go
@@ -24,6 +24,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
+const liquidAsset = "lbtc"
+
 type PeerswapServer struct {
 	liquidWallet   wallet.Wallet
 	swaps          *swap.SwapService
@@ -110,6 +112,9 @@ func NewPeerswapServer(
 }
 
 func (p *PeerswapServer) SwapOut(ctx context.Context, request *SwapOutRequest) (*SwapResponse, error) {
+	if request.GetAsset() == liquidAsset {
+		return nil, swap.ErrNewLiquidSwapsDisabled
+	}
 	if request.SwapAmount <= 0 {
 		return nil, errors.New("Missing required swap_amount parameter")
 	}
@@ -217,6 +222,9 @@ func (p *PeerswapServer) isPeerConnected(ctx context.Context, peerId string) boo
 }
 
 func (p *PeerswapServer) SwapIn(ctx context.Context, request *SwapInRequest) (*SwapResponse, error) {
+	if request.GetAsset() == liquidAsset {
+		return nil, swap.ErrNewLiquidSwapsDisabled
+	}
 	var swapchan *lnrpc.Channel
 	chans, err := p.lnd.ListChannels(ctx, &lnrpc.ListChannelsRequest{ActiveOnly: true})
 	if err != nil {

--- a/peersync/liquid_suspension_test.go
+++ b/peersync/liquid_suspension_test.go
@@ -1,0 +1,25 @@
+package peersync
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSuspensionOmitsLiquidFromLocalCapability(t *testing.T) {
+	ps, _ := newTestPeerSync(t)
+	for _, assets := range [][]Asset{{AssetBTC, AssetLBTC}, {AssetLBTC}, {AssetBTC}} {
+		ps.supportedAssets = assets
+		capability := ps.localCapabilityForPeer(PeerID{})
+		for _, asset := range capability.SupportedAssets() {
+			if asset == AssetLBTC {
+				t.Fatal("advertised suspended L-BTC")
+			}
+		}
+		if !reflect.DeepEqual(assets, ps.supportedAssets) {
+			t.Fatal("changed backend assets")
+		}
+		if len(assets) == 1 && assets[0] == AssetLBTC && len(capability.SupportedAssets()) != 0 {
+			t.Fatal("Liquid-only node must advertise no available assets")
+		}
+	}
+}

--- a/peersync/message_handler.go
+++ b/peersync/message_handler.go
@@ -55,6 +55,14 @@ func (h *messageHandler) processMessage(ctx context.Context, msg CustomMessage) 
 		h.handlePollMessage(ctx, msg)
 	case messages.MESSAGETYPE_REQUEST_POLL:
 		h.handleRequestPollMessage(ctx, msg)
+	case messages.MESSAGETYPE_SWAPINREQUEST,
+		messages.MESSAGETYPE_SWAPOUTREQUEST,
+		messages.MESSAGETYPE_SWAPINAGREEMENT,
+		messages.MESSAGETYPE_SWAPOUTAGREEMENT,
+		messages.MESSAGETYPE_OPENINGTXBROADCASTED,
+		messages.MESSAGETYPE_CANCELED,
+		messages.MESSAGETYPE_COOPCLOSE:
+		// The swap service handles these messages independently.
 	default:
 		log.Printf("unknown message type: %v", msg.Type)
 	}

--- a/peersync/message_handler_test.go
+++ b/peersync/message_handler_test.go
@@ -1,0 +1,33 @@
+package peersync
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+
+	"github.com/elementsproject/peerswap/messages"
+)
+
+func TestCapabilityHandlerIgnoresSwapMessages(t *testing.T) {
+	var output bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	h := &messageHandler{}
+	for _, kind := range []messages.MessageType{
+		messages.MESSAGETYPE_SWAPINREQUEST, messages.MESSAGETYPE_SWAPOUTREQUEST,
+		messages.MESSAGETYPE_SWAPINAGREEMENT, messages.MESSAGETYPE_SWAPOUTAGREEMENT,
+		messages.MESSAGETYPE_OPENINGTXBROADCASTED, messages.MESSAGETYPE_CANCELED,
+		messages.MESSAGETYPE_COOPCLOSE,
+	} {
+		h.processMessage(context.Background(), CustomMessage{Type: kind})
+	}
+	if output.Len() != 0 {
+		t.Fatalf("unexpected log: %s", output.String())
+	}
+	h.processMessage(context.Background(), CustomMessage{Type: 1})
+	if !bytes.Contains(output.Bytes(), []byte("unknown message type")) {
+		t.Fatal("unknown type should still be logged")
+	}
+}

--- a/peersync/peersync.go
+++ b/peersync/peersync.go
@@ -244,8 +244,14 @@ func (ps *PeerSync) Stop() error {
 }
 
 func (ps *PeerSync) localCapabilityForPeer(peer PeerID) *PeerCapability {
-	assets := make([]Asset, len(ps.supportedAssets))
-	copy(assets, ps.supportedAssets)
+	// Backend availability is retained for recovery, but L-BTC must not be
+	// advertised as available for new swaps during the suspension.
+	assets := make([]Asset, 0, len(ps.supportedAssets))
+	for _, asset := range ps.supportedAssets {
+		if asset != AssetLBTC {
+			assets = append(assets, asset)
+		}
+	}
 
 	allowed := true
 	if ps.guard != nil {

--- a/swap/liquid_suspension.go
+++ b/swap/liquid_suspension.go
@@ -1,0 +1,34 @@
+package swap
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNewLiquidSwapsDisabled applies only to new swaps. Liquid services must
+// remain enabled so that persisted swaps can still be recovered.
+var ErrNewLiquidSwapsDisabled = errors.New("new L-BTC swaps are disabled due to the Liquid network security incident")
+
+func (s *SwapService) rejectNewLiquidSwap(id *SwapId, peer string) error {
+	if id == nil {
+		return errors.New("missing swap id")
+	}
+	// Do not send a cancellation for a retransmission of an existing swap.
+	if existing, err := s.GetActiveSwap(id.String()); err == nil {
+		if existing.Data.PeerNodeId != peer {
+			return ErrReceivedMessageFromUnexpectedPeer(peer, id)
+		}
+		return AlreadyExistsError
+	}
+	payload, kind, err := MarshalPeerswapMessage(&CancelMessage{
+		SwapId:  id,
+		Message: ErrNewLiquidSwapsDisabled.Error(),
+	})
+	if err != nil {
+		return err
+	}
+	if err := s.swapServices.messenger.SendMessage(peer, payload, kind); err != nil {
+		return fmt.Errorf("%w: sending cancellation: %w", ErrNewLiquidSwapsDisabled, err)
+	}
+	return ErrNewLiquidSwapsDisabled
+}

--- a/swap/liquid_suspension_test.go
+++ b/swap/liquid_suspension_test.go
@@ -1,0 +1,182 @@
+package swap
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/elementsproject/peerswap/messages"
+	"go.etcd.io/bbolt"
+)
+
+const suspensionBitcoinNetwork = "mainnet"
+
+type suspensionMessenger struct {
+	peer    string
+	kind    int
+	payload []byte
+}
+
+func (m *suspensionMessenger) AddMessageHandler(func(string, string, []byte) error) {}
+func (m *suspensionMessenger) SendMessage(peer string, payload []byte, kind int) error {
+	m.peer, m.payload, m.kind = peer, payload, kind
+	return nil
+}
+
+func TestNewLiquidSwapsDisabledBeforeSideEffects(t *testing.T) {
+	// No dependencies: any wallet, invoice, policy or chain call would panic.
+	s := &SwapService{}
+	_, err := s.SwapIn("peer", l_btc_chain, "channel", "local", 100000, 0)
+	if err := err; !errors.Is(err, ErrNewLiquidSwapsDisabled) {
+		t.Fatalf("got %v, want %v", err, ErrNewLiquidSwapsDisabled)
+	}
+	_, err = s.SwapOut("peer", l_btc_chain, "channel", "local", 100000, 0)
+	if err := err; !errors.Is(err, ErrNewLiquidSwapsDisabled) {
+		t.Fatalf("got %v, want %v", err, ErrNewLiquidSwapsDisabled)
+	}
+}
+
+func TestRemoteLiquidRequestsRejected(t *testing.T) {
+	for _, network := range []string{"", suspensionBitcoinNetwork} {
+		for _, direction := range []string{"in", "out"} {
+			t.Run(network+"/"+direction, func(t *testing.T) {
+				id := NewSwapId()
+				m := &suspensionMessenger{}
+				s := &SwapService{
+					swapServices: &SwapServices{messenger: m},
+					activeSwaps:  map[string]*SwapStateMachine{},
+					lastMsgLog:   map[string]string{},
+				}
+				var msg PeerMessage = &SwapInRequestMessage{SwapId: id, Asset: "liquid-asset", Network: network}
+				if direction == "out" {
+					msg = &SwapOutRequestMessage{SwapId: id, Asset: "liquid-asset", Network: network}
+				}
+				payload, kind, err := MarshalPeerswapMessage(msg)
+				assertNoError(t, err)
+				err = s.OnMessageReceived("peer", messages.MessageTypeToHexString(messages.MessageType(kind)), payload)
+				if err := err; !errors.Is(err, ErrNewLiquidSwapsDisabled) {
+					t.Fatalf("got %v, want %v", err, ErrNewLiquidSwapsDisabled)
+				}
+				assertEqual(t, 0, len(s.activeSwaps))
+				assertEqual(t, "peer", m.peer)
+				assertEqual(t, int(messages.MESSAGETYPE_CANCELED), m.kind)
+				var cancel CancelMessage
+				assertNoError(t, json.Unmarshal(m.payload, &cancel))
+				assertEqual(t, id.String(), cancel.SwapId.String())
+				assertEqual(t, ErrNewLiquidSwapsDisabled.Error(), cancel.Message)
+			})
+		}
+	}
+}
+
+func TestLiquidRetransmissionDoesNotCancelExistingSwap(t *testing.T) {
+	id := NewSwapId()
+	m := &suspensionMessenger{}
+	existing := &SwapStateMachine{Data: &SwapData{PeerNodeId: "peer"}, Current: State_WaitCsv}
+	s := &SwapService{
+		swapServices: &SwapServices{messenger: m},
+		activeSwaps:  map[string]*SwapStateMachine{id.String(): existing},
+	}
+	if err := s.OnSwapInRequestReceived(id, "peer", &SwapInRequestMessage{}); !errors.Is(err, AlreadyExistsError) {
+		t.Fatalf("got %v, want %v", err, AlreadyExistsError)
+	}
+	if err := s.OnSwapOutRequestReceived(id, "peer", &SwapOutRequestMessage{}); !errors.Is(err, AlreadyExistsError) {
+		t.Fatalf("got %v, want %v", err, AlreadyExistsError)
+	}
+	if err := s.OnSwapInRequestReceived(id, "other", &SwapInRequestMessage{}); err == nil {
+		t.Fatal("expected an error")
+	}
+	assertEqual(t, 0, len(m.payload))
+	assertEqual(t, State_WaitCsv, existing.Current)
+}
+
+// recoveryChain records the watch installed when a persisted swap is restored.
+type recoveryChain struct {
+	dummyChain
+	watchedCSV uint32
+	watchedID  string
+}
+
+func (c *recoveryChain) AddWaitForCsvTx(id, _ string, _, _, csv uint32, _ []byte) {
+	c.watchedID, c.watchedCSV = id, csv
+}
+
+func TestSuspensionPreservesPersistedLiquidRecovery(t *testing.T) {
+	for _, direction := range []SwapType{SWAPTYPE_IN, SWAPTYPE_OUT} {
+		for _, claim := range []string{"csv", "coop"} {
+			t.Run(direction.String()+"/"+claim, func(t *testing.T) {
+				services := getSwapServices(t, nil)
+				services.bitcoinEnabled = false
+				db, err := bbolt.Open(filepath.Join(t.TempDir(), "swaps.db"), 0o600, nil)
+				assertNoError(t, err)
+				t.Cleanup(func() { assertNoError(t, db.Close()) })
+				store, err := NewBboltStore(db)
+				assertNoError(t, err)
+				services.swapStore = store
+				chain := &recoveryChain{}
+				services.liquidTxWatcher = chain
+				services.liquidWallet = chain
+				services.liquidValidator = chain
+				id := NewSwapId()
+				data := NewSwapData(id, "local", "peer")
+				data.OpeningTxBroadcasted = &OpeningTxBroadcastedMessage{SwapId: id, TxId: getRandom32ByteHexString()}
+				data.OpeningTxHex = "opening"
+				role := SWAPROLE_SENDER
+				if direction == SWAPTYPE_IN {
+					data.SwapInRequest = &SwapInRequestMessage{
+						SwapId:          id,
+						Asset:           l_btc_chain,
+						ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
+						Scid:            "channel",
+						Amount:          100000,
+					}
+				} else {
+					role = SWAPROLE_RECEIVER
+					data.SwapOutRequest = &SwapOutRequestMessage{
+						SwapId:          id,
+						Asset:           l_btc_chain,
+						ProtocolVersion: PEERSWAP_PROTOCOL_VERSION,
+						Scid:            "channel",
+						Amount:          100000,
+					}
+				}
+				data.SwapInAgreement = &SwapInAgreementMessage{SwapId: id, ProtocolVersion: PEERSWAP_PROTOCOL_VERSION}
+				data.SwapOutAgreement = &SwapOutAgreementMessage{SwapId: id, ProtocolVersion: PEERSWAP_PROTOCOL_VERSION}
+
+				data.Role = role
+				saved := &SwapStateMachine{SwapId: id, Data: data, Type: direction, Role: role, Current: State_WaitCsv}
+				assertNoError(t, store.UpdateData(saved))
+				service := NewSwapService(services)
+				assertNoError(t, service.Start())
+				assertEqual(t, true, service.LiquidEnabled)
+				assertEqual(t, false, service.BitcoinEnabled)
+				assertNoError(t, service.RecoverSwaps())
+				restored, err := service.GetActiveSwap(id.String())
+				assertNoError(t, err)
+				assertEqual(t, State_WaitCsv, restored.Current)
+				assertEqual(t, id.String(), chain.watchedID)
+				assertEqual(t, uint32(10080), chain.watchedCSV)
+				assertEqual(t, 0, len(restored.Data.ClaimTxId))
+				// With no CSV event the restored swap remains waiting. No wall-clock
+				// deadline is substituted for Liquid block progress.
+				if claim == "csv" {
+					assertNoError(t, service.OnCsvPassed(id.String()))
+					assertEqual(t, State_ClaimedCsv, restored.Current)
+				} else {
+					assertNoError(
+						t,
+						service.OnCoopCloseReceived(
+							id,
+							&CoopCloseMessage{SwapId: id, Privkey: getRandom32ByteHexString()},
+						),
+					)
+					assertEqual(t, State_ClaimedCoop, restored.Current)
+				}
+				if len(restored.Data.ClaimTxId) == 0 {
+					t.Fatal("expected a claim transaction")
+				}
+			})
+		}
+	}
+}

--- a/swap/service.go
+++ b/swap/service.go
@@ -376,6 +376,9 @@ func (s *SwapService) OnCsvPassed(swapId string) error {
 // todo move wallet and chain / channel validation logic here
 // SwapOut starts a new swap out process
 func (s *SwapService) SwapOut(peer string, chain string, channelId string, initiator string, amtSat uint64, premiumLimitRatePpm int64) (*SwapStateMachine, error) {
+	if chain == l_btc_chain {
+		return nil, ErrNewLiquidSwapsDisabled
+	}
 	if !s.swapServices.policy.NewSwapsAllowed() {
 		return nil, fmt.Errorf("swaps are disabled")
 	}
@@ -441,6 +444,9 @@ func (s *SwapService) SwapOut(peer string, chain string, channelId string, initi
 // todo check prerequisites
 // SwapIn starts a new swap in process
 func (s *SwapService) SwapIn(peer string, chain string, channelId string, initiator string, amtSat uint64, premiumLimitRatePPM int64) (*SwapStateMachine, error) {
+	if chain == l_btc_chain {
+		return nil, ErrNewLiquidSwapsDisabled
+	}
 	if !s.swapServices.policy.NewSwapsAllowed() {
 		return nil, fmt.Errorf("swaps are disabled")
 	}
@@ -543,6 +549,9 @@ func (s *SwapService) estimateMaximumSwapAmountSat(chain string) (uint64, error)
 
 // OnSwapInRequestReceived creates a new swap-in process and sends the event to the swap statemachine
 func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, message *SwapInRequestMessage) error {
+	if message.Network == "" || message.Asset != "" {
+		return s.rejectNewLiquidSwap(swapId, peerId)
+	}
 	var (
 		premiumValue int64
 		err          error
@@ -654,6 +663,9 @@ func (s *SwapService) OnSwapInRequestReceived(swapId *SwapId, peerId string, mes
 
 // OnSwapOutRequestReceived creates a new swap-out process and sends the event to the swap statemachine
 func (s *SwapService) OnSwapOutRequestReceived(swapId *SwapId, peerId string, message *SwapOutRequestMessage) error {
+	if message.Network == "" || message.Asset != "" {
+		return s.rejectNewLiquidSwap(swapId, peerId)
+	}
 	var (
 		premiumValue int64
 		err          error

--- a/swap/service_test.go
+++ b/swap/service_test.go
@@ -228,12 +228,12 @@ func Test_OnlyOneActiveSwapPerChannel(t *testing.T) {
 		failures: 0,
 	})
 
-	_, err := service.SwapOut("peer", "lbtc", "channelID", "alice", uint64(100000), 0)
+	_, err := service.SwapOut("peer", "btc", "channelID", "alice", uint64(100000), 0)
 	assert.Error(t, err, "expected error")
 	assert.ErrorIs(t, err, ActiveSwapError{channelId: "channelID", swapId: swapId.String()})
 	t.Logf("Got Error: %s", err.Error())
 
-	_, err = service.SwapIn("peer", "lbtc", "channelID", "alice", uint64(100000), 0)
+	_, err = service.SwapIn("peer", "btc", "channelID", "alice", uint64(100000), 0)
 	assert.Error(t, err, "expected error")
 	assert.ErrorIs(t, err, ActiveSwapError{channelId: "channelID", swapId: swapId.String()})
 	t.Logf("Got Error: %s", err.Error())
@@ -302,8 +302,16 @@ func TestMessageFromUnexpectedPeer(t *testing.T) {
 		{name: "opening tx broadcasted message", message: &OpeningTxBroadcastedMessage{SwapId: aliceSwap.SwapId}, assertError: true},
 		{name: "coop close message", message: &CoopCloseMessage{SwapId: aliceSwap.SwapId}, assertError: true},
 		{name: "cancel message", message: &CancelMessage{SwapId: aliceSwap.SwapId}, assertError: true},
-		{name: "swap in request message", message: &SwapInRequestMessage{SwapId: NewSwapId()}, assertError: false},
-		{name: "swap out request message", message: &SwapOutRequestMessage{SwapId: NewSwapId()}, assertError: false},
+		{
+			name:        "swap in request message",
+			message:     &SwapInRequestMessage{SwapId: NewSwapId(), Network: suspensionBitcoinNetwork},
+			assertError: false,
+		},
+		{
+			name:        "swap out request message",
+			message:     &SwapOutRequestMessage{SwapId: NewSwapId(), Network: suspensionBitcoinNetwork},
+			assertError: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/test/liquid_suspension_test.go
+++ b/test/liquid_suspension_test.go
@@ -1,0 +1,96 @@
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elementsproject/peerswap/clightning"
+	"github.com/elementsproject/peerswap/peerswaprpc"
+	"github.com/elementsproject/peerswap/swap"
+	"github.com/elementsproject/peerswap/testframework"
+)
+
+// During the suspension, the Liquid matrix checks rejection instead of
+// attempting to create new contracts. Persisted recovery is tested separately.
+func runLiquidSuspension(t *testing.T, vector string) {
+	t.Helper()
+	IsIntegrationTest(t)
+	lwk := strings.HasPrefix(vector, "lwk_")
+	if lwk {
+		skipLWKTests(t)
+	}
+	var nodes []testframework.LightningNode
+	var daemons []*PeerSwapd
+	switch {
+	case strings.HasSuffix(vector, "clncln"):
+		if lwk {
+			_, _, clns, _, _, _ := clnclnLWKSetup(t, 1000000)
+			for _, n := range clns {
+				nodes = append(nodes, n)
+			}
+		} else {
+			_, _, clns, _ := clnclnElementsSetup(t, 1000000)
+			for _, n := range clns {
+				nodes = append(nodes, n)
+			}
+		}
+	case strings.HasSuffix(vector, "lndlnd"):
+		if lwk {
+			_, _, lnds, ps, _, _, _ := lndlndLWKSetup(t, 1000000)
+			daemons = ps
+			for _, n := range lnds {
+				nodes = append(nodes, n)
+			}
+		} else {
+			_, _, lnds, ps, _ := lndlndElementsSetup(t, 1000000)
+			daemons = ps
+			for _, n := range lnds {
+				nodes = append(nodes, n)
+			}
+		}
+	case strings.HasSuffix(vector, "mixed"):
+		if lwk {
+			_, _, ns, ps, _, _, _ := mixedLWKSetup(t, 1000000, FunderCLN)
+			nodes, daemons = ns, []*PeerSwapd{ps}
+		} else {
+			_, _, ns, ps, _ := mixedElementsSetup(t, 1000000, FunderCLN)
+			nodes, daemons = ns, []*PeerSwapd{ps}
+		}
+	default:
+		t.Fatalf("unknown Liquid test vector: %s", vector)
+	}
+	for _, node := range nodes {
+		cln, ok := node.(*CLightningNodeWithLiquid)
+		if !ok {
+			continue
+		}
+		var result interface{}
+		err := cln.Rpc.Request(&clightning.SwapIn{Asset: "lbtc", SatAmt: 100000, ShortChannelId: "1x1x1"}, &result)
+		assertSuspended(t, err)
+		err = cln.Rpc.Request(
+			&clightning.SwapOut{Asset: "lbtc", SatAmt: 100000, ShortChannelId: "1x1x1", Force: true},
+			&result,
+		)
+		assertSuspended(t, err)
+	}
+	for _, ps := range daemons {
+		_, err := ps.PeerswapClient.SwapIn(
+			context.Background(),
+			&peerswaprpc.SwapInRequest{Asset: "lbtc", SwapAmount: 100000, ChannelId: 1},
+		)
+		assertSuspended(t, err)
+		_, err = ps.PeerswapClient.SwapOut(
+			context.Background(),
+			&peerswaprpc.SwapOutRequest{Asset: "lbtc", SwapAmount: 100000, ChannelId: 1, Force: true},
+		)
+		assertSuspended(t, err)
+	}
+}
+
+func assertSuspended(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), swap.ErrNewLiquidSwapsDisabled.Error()) {
+		t.Fatalf("got %v, want Liquid suspension error", err)
+	}
+}

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -3,6 +3,8 @@ package test
 import (
 	"errors"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -278,7 +280,12 @@ func Test_Recover_PassedSwap_LBTC(t *testing.T) {
 
 	require := requireNew(t)
 
-	bitcoind, liquidd, lightningds, scid := clnclnElementsSetup(t, uint64(math.Pow10(6)))
+	currentPlugin := NewHarnessBuilder(t).peerswapPluginPath
+	legacyPlugin := filepath.Join(filepath.Dir(currentPlugin), "peerswap-v7.0.0")
+	if _, err := os.Stat(legacyPlugin); err != nil {
+		t.Fatalf("run make legacy-test-plugin first: %v", err)
+	}
+	bitcoind, liquidd, lightningds, scid := clnclnElementsSetupWithPlugin(t, uint64(math.Pow10(6)), legacyPlugin)
 	DumpOnFailure(t, WithBitcoin(bitcoind), WithLiquid(liquidd), WithCLightningNodes(lightningds, nil))
 
 	var channelBalances []uint64
@@ -363,6 +370,12 @@ func Test_Recover_PassedSwap_LBTC(t *testing.T) {
 
 	// Stop taker peer so that csv can trigger
 	require.NoError(params.takerNode.Stop())
+	// Restart the existing data directory using the suspended version.
+	for i, arg := range params.takerPeerswap.CmdLine {
+		if arg == "--plugin="+legacyPlugin {
+			params.takerPeerswap.CmdLine[i] = "--plugin=" + currentPlugin
+		}
+	}
 
 	// Generate enough blocks to trigger csv
 	require.NoError(params.chaind.GenerateBlocks(params.csv + 50))

--- a/test/setup.go
+++ b/test/setup.go
@@ -222,8 +222,20 @@ func clnclnElementsSetup(
 	fundAmt uint64,
 ) (*testframework.BitcoinNode, *testframework.LiquidNode, []*CLightningNodeWithLiquid, string) {
 	t.Helper()
+	return clnclnElementsSetupWithPlugin(t, fundAmt, "")
+}
+
+func clnclnElementsSetupWithPlugin(
+	t *testing.T,
+	fundAmt uint64,
+	plugin string,
+) (*testframework.BitcoinNode, *testframework.LiquidNode, []*CLightningNodeWithLiquid, string) {
+	t.Helper()
 
 	builder := NewHarnessBuilder(t)
+	if plugin != "" {
+		builder.peerswapPluginPath = plugin
+	}
 	bitcoind := builder.Bitcoind()
 
 	liquidd, err := testframework.NewLiquidNode(builder.TestDir(), bitcoind, 1)
@@ -236,6 +248,7 @@ func clnclnElementsSetup(
 	for i := 1; i <= 2; i++ {
 		walletName := fmt.Sprintf("swap%d", i)
 		cfg := mustToml(t, map[string]any{
+			"bitcoin": map[string]any{"enabled": false},
 			"liquid": map[string]any{
 				"rpcuser":     liquidd.RpcUser,
 				"rpcpassword": liquidd.RpcPassword,

--- a/test/swap_matrix_test.go
+++ b/test/swap_matrix_test.go
@@ -3,15 +3,16 @@ package test
 import (
 	"math"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/elementsproject/peerswap/swap"
 )
 
 func Test_SwapInMatrix(t *testing.T) {
-    t.Helper()
-    // Run this top-level matrix in parallel with others to reduce CI wall time.
-    t.Parallel()
+	t.Helper()
+	// Run this top-level matrix in parallel with others to reduce CI wall time.
+	t.Parallel()
 
 	cases := []struct {
 		name string
@@ -30,6 +31,10 @@ func Test_SwapInMatrix(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if strings.HasPrefix(tc.name, "liquid_") || strings.HasPrefix(tc.name, "lwk_") {
+				runLiquidSuspension(t, tc.name)
+				return
+			}
 			tc.run(t)
 		})
 	}
@@ -343,9 +348,9 @@ func runLwkLndLndSwapIn(t *testing.T) {
 }
 
 func Test_SwapOutMatrix(t *testing.T) {
-    t.Helper()
-    // Run this top-level matrix in parallel with others to reduce CI wall time.
-    t.Parallel()
+	t.Helper()
+	// Run this top-level matrix in parallel with others to reduce CI wall time.
+	t.Parallel()
 
 	cases := []struct {
 		name string
@@ -364,6 +369,10 @@ func Test_SwapOutMatrix(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if strings.HasPrefix(tc.name, "liquid_") || strings.HasPrefix(tc.name, "lwk_") {
+				runLiquidSuspension(t, tc.name)
+				return
+			}
 			tc.run(t)
 		})
 	}


### PR DESCRIPTION
Disable new L-BTC swap requests for v7.0.1 following the [public Liquid Network security incident](https://x.com/Liquid_BTC/status/2096696272447218108).

Both local RPC requests and incoming peer requests are rejected in both directions, including forced requests. L-BTC is omitted from capability announcements. Bitcoin swaps retain their existing behavior.

Liquid backend initialization, persisted swaps, and recovery callbacks remain enabled, including when Bitcoin swaps are disabled. Recovery still depends on Liquid network availability and the recovered chain; this change does not guarantee recovery. The README includes the official statement and screenshot.

Also stop the capability handler from incorrectly logging recognized swap messages, including `SwapInAgreement` (42073), as unknown. The existing swap handler continues to process them.

Validation:
- Unit/race suite, builds, and diff lint pass locally.
- Tests cover rejected requests, retransmissions, and persisted CSV/cooperative recovery with Bitcoin disabled.
- Liquid integration cases now check suspension. A pinned v7.0.0 fixture exercises restarting an existing swap with the updated plugin.
- Live-node integration requires Linux and will be verified in CI. Warren will separately test the recovery-only configuration.
